### PR TITLE
fix: properly use multi name fields

### DIFF
--- a/entfga/template.go
+++ b/entfga/template.go
@@ -42,9 +42,9 @@ func extractDefaultObjectType(val any) string {
 		return ""
 	}
 
-	schemaName = strings.ToLower(schemaName)
+	schemaName = strcase.SnakeCase(schemaName)
 
-	return strings.ReplaceAll(schemaName, "history", "")
+	return strings.Trim(strings.ReplaceAll(schemaName, "history", ""), "_")
 }
 
 // extractIDField gets the key that is used for the id field

--- a/entfga/template_test.go
+++ b/entfga/template_test.go
@@ -54,6 +54,11 @@ func TestExtractDefaultObjectType(t *testing.T) {
 			expected: "user",
 		},
 		{
+			name:     "valid schema name",
+			input:    "ControlObjective",
+			expected: "control_objective",
+		},
+		{
 			name:     "valid schema name, lowercase",
 			input:    "userhistory",
 			expected: "user",


### PR DESCRIPTION
Fixing all our multi-word schemas to use snake case consistently (e.g. `actionplan` should be `action_plan`). The generated checks are all one word. This will be a breaking change to the `openlane/core` repo. 

Related PR: https://github.com/theopenlane/entx/pull/63