### PR TITLE
feat: fixup access to history

### DIFF
--- a/entfga/template.go
+++ b/entfga/template.go
@@ -47,6 +47,11 @@ func extractDefaultObjectType(val any) string {
 	return strings.Trim(strings.ReplaceAll(schemaName, "history", ""), "_")
 }
 
+// isHistorySchema checks if the schema name contains the word "history"
+func isHistorySchema(schemaName string) bool {
+	return strings.Contains(schemaName, "History")
+}
+
 // extractIDField gets the key that is used for the id field
 func extractIDField(val any) string {
 	idField, ok := val.(string)
@@ -172,6 +177,7 @@ func parseAuthzChecksTemplate(info templateInfo) error {
 		"hasCreateID":              hasCreateID,
 		"hasMutationInputSet":      hasMutationInputSet,
 		"ToLower":                  strings.ToLower,
+		"isHistorySchema":          isHistorySchema,
 	})
 
 	// parse the template

--- a/entfga/templates/authzChecks.tmpl
+++ b/entfga/templates/authzChecks.tmpl
@@ -22,6 +22,7 @@ var (
     {{- $defaultObjectType := extractDefaultObjectType $n.Name }}
     {{- $mutator := $n.MutationName }}
     {{- $querier := $n.QueryName }}
+    {{- $isHistory := isHistorySchema $querier }}
 
     {{/* Only include nodes with the Authz check anntoation. See: Annotations.Name */}}
     {{- if $n.Annotations.Authz }}
@@ -90,7 +91,11 @@ var (
 
         // check if the user has access to the object requested
         ac := fgax.AccessCheck{
+            {{- if $isHistory }}
+            Relation: fgax.CanViewAuditLog,
+            {{- else }}
             Relation: fgax.CanView,
+            {{- end }}
             ObjectType:  "{{ $objectType | ToLower }}",
             SubjectType: auth.GetAuthzSubjectType(ctx),
             SubjectID: subjectID,

--- a/fgax/tuples.go
+++ b/fgax/tuples.go
@@ -50,6 +50,8 @@ const (
 	CanInviteMembers = "can_invite_members"
 	// CanInviteAdmins is the relation for inviting admins to an entity
 	CanInviteAdmins = "can_invite_admins"
+	// CanViewAuditLog is the relation for viewing the audit log of an entity
+	CanViewAuditLog = "audit_log_viewer"
 )
 
 const (


### PR DESCRIPTION
I don't think we need the policies anymore (see https://github.com/theopenlane/entx/pull/74) but leaving for now even though they are not used in the generated schema. 