### PR TITLE
feat: api key header, logging of totp errors, fix nil redis bug

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -14,6 +14,8 @@ import (
 const (
 	// Authorization is the key used in HTTP headers or cookies to represent the authorization token
 	Authorization = "Authorization"
+	// APIKeyHeader is the key used in HTTP headers to represent the API key
+	APIKeyHeader = "X-API-Key" //nolint:gosec
 	// AccessTokenCookie is the key used in cookies to represent the access token
 	AccessTokenCookie = "access_token"
 	// RefreshTokenCookie is the key used in cookies to represent the refresh token
@@ -53,6 +55,16 @@ func GetAccessToken(c echo.Context) (string, error) {
 	}
 
 	return "", ErrNoAuthorization
+}
+
+// GetAPIKey retrieves the API key from the authorization header or the X-API-Key header.
+func GetAPIKey(c echo.Context) (string, error) {
+	// Attempt to get the api token from the header
+	if h := c.Request().Header.Get(APIKeyHeader); h != "" {
+		return h, nil
+	}
+
+	return "", ErrNoAPIKey
 }
 
 // GetRefreshToken retrieves the refresh token from the cookies in the request. If the

--- a/auth/errors.go
+++ b/auth/errors.go
@@ -17,6 +17,8 @@ var (
 	ErrParseBearer = errors.New("could not parse bearer token from authorization header")
 	// ErrNoAuthorization is returned when no authorization header is found in the request
 	ErrNoAuthorization = errors.New("no authorization header in request")
+	// ErrNoAPIKey is returned when no API key is found in the request
+	ErrNoAPIKey = errors.New("no API key found in request")
 	// ErrNoRequest is returned when no request is found on the context
 	ErrNoRequest = errors.New("no request found on the context")
 	// ErrNoRefreshToken is returned when no refresh token is found on the request

--- a/totp/errors.go
+++ b/totp/errors.go
@@ -65,6 +65,9 @@ var (
 	// ErrIncorrectCodeProvided is an error representing an incorrect code provided
 	ErrIncorrectCodeProvided = errors.New("incorrect code provided")
 
+	// ErrCannotEncryptSecret is an error representing a failure to encrypt secret
+	ErrCannotEncryptSecret = errors.New("cannot encrypt secret")
+
 	// ErrCannotDecryptSecret is an error representing a failure to decrypt secret
 	ErrCannotDecryptSecret = errors.New("cannot decrypt secret")
 

--- a/totp/totp.go
+++ b/totp/totp.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pquerna/otp"
 	"github.com/pquerna/otp/totp"
 	"github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -92,12 +93,16 @@ func (o *OTP) TOTPSecret(u *User) (string, error) {
 		AccountName: u.DefaultName(),
 	})
 	if err != nil {
+		log.Err(err).Msg("failed to generate TOTP secret")
+
 		return "", ErrFailedToGenerateSecret
 	}
 
 	encryptedKey, err := o.encrypt(key.Secret())
 	if err != nil {
-		return "", ErrCannotDecryptSecret
+		log.Err(err).Msg("failed to generate TOTP secret")
+
+		return "", ErrCannotEncryptSecret
 	}
 
 	return encryptedKey, nil

--- a/totp/totp.go
+++ b/totp/totp.go
@@ -172,6 +172,13 @@ func (o *OTP) ValidateTOTP(ctx context.Context, user *User, code string) error {
 
 	key := fmt.Sprintf("%s_%s", user.ID, code)
 
+	// redis is not configured, we can't invalidate the code for future checks
+	if o.db == nil {
+		log.Warn().Msg("redis is not configured, code will not be invalidated")
+
+		return nil
+	}
+
 	// Validated code has previously been used in the past thirty seconds
 	if err = o.db.Get(ctx, key).Err(); err == nil {
 		return ErrCodeIsNoLongerValid


### PR DESCRIPTION
- We are swallowing the original totp errors without any logging so it was hard to tell the issue. This adds logging to a few totp errors
- Adds a function to use an api key header and get the value, this would allow us to use a different header for API key requests
- Handles the case where redis is not configured, to allow verification without invalidation