### PR TITLE
feat: otp recovery code defaults

### DIFF
--- a/totp/config.go
+++ b/totp/config.go
@@ -3,7 +3,7 @@ package totp
 const (
 	defaultLength             = 6
 	defaultRecoveryCodeCount  = 16
-	defaultRecoveryCodeLength = 10
+	defaultRecoveryCodeLength = 8
 	codePeriod                = 30
 )
 

--- a/totp/totp.go
+++ b/totp/totp.go
@@ -384,8 +384,8 @@ func GenerateOTP(secret string) (string, error) {
 func (o *OTP) GenerateRecoveryCodes() []string {
 	codes := []string{}
 
-	// for range o.recoveryCodeCount { // this works in go 1.22 but the linter barfs while its still on 1.21
-	for i := 1; i <= o.recoveryCodeCount; i++ {
+	for range o.recoveryCodeCount {
+		log.Debug().Int("length", o.recoveryCodeLength).Msg("generating recovery code")
 		code, err := String(o.recoveryCodeLength, alphanumericCode)
 		if err != nil {
 			continue

--- a/totp/totp.go
+++ b/totp/totp.go
@@ -385,7 +385,6 @@ func (o *OTP) GenerateRecoveryCodes() []string {
 	codes := []string{}
 
 	for range o.recoveryCodeCount {
-		log.Debug().Int("length", o.recoveryCodeLength).Msg("generating recovery code")
 		code, err := String(o.recoveryCodeLength, alphanumericCode)
 		if err != nil {
 			continue


### PR DESCRIPTION
The config default for recovery code length did not match the hardcoded default. This allows them to be the same at 8. 