### PR TITLE
feat: allow bypass of duplicate errors

### DIFF
--- a/fgax/fga.go
+++ b/fgax/fga.go
@@ -15,6 +15,8 @@ type Client struct {
 	Ofga ofgaclient.SdkClient
 	// Config is the client configuration
 	Config ofgaclient.ClientConfiguration
+	// IgnoreDuplicateKeyError ignores the error when a key already exists or a delete request is made for a non-existent key
+	IgnoreDuplicateKeyError bool
 }
 
 // Config configures the openFGA setup
@@ -35,6 +37,8 @@ type Config struct {
 	ModelFile string `json:"modelFile" koanf:"modelFile" jsonschema:"description=path to the fga model file" default:"fga/model/model.fga"`
 	// Credentials for the client
 	Credentials Credentials `json:"credentials" koanf:"credentials" jsonschema:"description=credentials for the openFGA client"`
+	// IgnoreDuplicateKeyError ignores the error when a key already exists or a delete request is made for a non-existent key
+	IgnoreDuplicateKeyError bool `json:"ignoreDuplicateKeyError" koanf:"ignoreDuplicateKeyError" jsonschema:"description=ignore duplicate key error" default:"true"`
 }
 
 // Credentials for the openFGA client
@@ -142,9 +146,17 @@ func WithToken(token string) Option {
 	}
 }
 
+func WithIgnoreDuplicateKeyError(ignore bool) Option {
+	return func(c *Client) {
+		c.IgnoreDuplicateKeyError = ignore
+	}
+}
+
 // CreateFGAClientWithStore returns a Client with a store and model configured
 func CreateFGAClientWithStore(ctx context.Context, c Config) (*Client, error) {
-	opts := []Option{}
+	opts := []Option{
+		WithIgnoreDuplicateKeyError(c.IgnoreDuplicateKeyError),
+	}
 
 	// set credentials if provided
 	if c.Credentials.APIToken != "" {

--- a/fgax/fga.go
+++ b/fgax/fga.go
@@ -146,6 +146,7 @@ func WithToken(token string) Option {
 	}
 }
 
+// WithIgnoreDuplicateKeyError sets whether the client should ignore duplicate key errors
 func WithIgnoreDuplicateKeyError(ignore bool) Option {
 	return func(c *Client) {
 		c.IgnoreDuplicateKeyError = ignore

--- a/fgax/testutils/container.go
+++ b/fgax/testutils/container.go
@@ -84,9 +84,10 @@ func (o *OpenFGATestFixture) NewFgaClient(ctx context.Context) (*fgax.Client, er
 	}
 
 	fgaConfig := fgax.Config{
-		StoreName: o.storeName,
-		HostURL:   host,
-		ModelFile: o.modelFile,
+		StoreName:               o.storeName,
+		HostURL:                 host,
+		ModelFile:               o.modelFile,
+		IgnoreDuplicateKeyError: true,
 	}
 
 	c, err := fgax.CreateFGAClientWithStore(ctx, fgaConfig)


### PR DESCRIPTION
When someone is doing an update on an object, they can add the same edge that already exists; however, we then try to re-add the tuple which fails. 

This change will ignore duplicate (or non-existent) keys and just log a warning. 

This is configurable by a config var, but defaults to `true`. 

The duplicate error string check is kind of annoying, and it's on the OpenFGA backlog of making it better, but for now its the best way. (They always return a 400/bad request on these and you have to string match the error)