### PR TITLE
port managed group context key and add orgsubscription context key

### DIFF
--- a/auth/context.go
+++ b/auth/context.go
@@ -38,6 +38,12 @@ type ContextRequestID struct {
 // OrganizationCreationContextKey is the context key name for the organization creation context
 type OrganizationCreationContextKey struct{}
 
+// ManagedGroupContextKey is the context key name for the managed group context
+type ManagedGroupContextKey struct{}
+
+// OrgSubscriptionContextKey is the context key name for the organization subscription context
+type OrgSubscriptionContextKey struct{}
+
 // AuthenticatedUser contains the user and organization ID for the authenticated user
 type AuthenticatedUser struct {
 	// SubjectID is the user ID of the authenticated user or the api token ID if the user is an API token


### PR DESCRIPTION
ports the `ManagedContextKey` -> `ManagedGroupContextKey` and adds the `OrgSubscriptionContextKey`