### PR TITLE
feat: return 401 error on session error, fix totp

### DIFF
--- a/sessions/cookie.go
+++ b/sessions/cookie.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	defaultMaxAgeSeconds = 1 * 60 // 1 hour (in seconds)
+	defaultMaxAgeSeconds = 60 * 60 // 1 hour (in seconds)
 )
 
 var (

--- a/sessions/cookie.go
+++ b/sessions/cookie.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	defaultMaxAgeSeconds = 60 * 60 // 1 hour (in seconds)
+	defaultMaxAgeSeconds = 1 * 60 // 1 hour (in seconds)
 )
 
 var (

--- a/sessions/sessions.go
+++ b/sessions/sessions.go
@@ -15,6 +15,8 @@ type Config struct {
 	EncryptionKey string `json:"encryptionKey" koanf:"encryptionKey" default:"encryptionsecret"`
 	// Domain is the domain for the cookie, leave empty to use the default value of the server
 	Domain string `json:"domain" koanf:"domain" default:""`
+	// MaxAge is the maximum age of the session cookie in seconds. After this time, the cookie will be invalidated
+	MaxAge int `json:"maxAge" koanf:"maxAge" default:"3600"` // 1 hour by default in seconds
 }
 
 // Session represents state values maintained in a sessions Store

--- a/totp/manager.go
+++ b/totp/manager.go
@@ -20,6 +20,11 @@ type TFAOptions string
 // MessageType describes a classification of a Message
 type MessageType string
 
+// Client manages the protocol for SMS/Email 2FA codes and TOTP codes
+type Client struct {
+	Manager Manager
+}
+
 const (
 	// OTPEmail allows a user to complete TFA with an OTP code delivered via email
 	OTPEmail TFAOptions = "otp_email"


### PR DESCRIPTION
- Returns 401 error instead of 500 when sessions are not valid:

```
 go run cmd/cli/main.go risk get  -z json -i01JQC5V8XZ
Error: {"networkErrors":{"code":401,"message":"Response body {\"success\":false,\"error\":\"invalid session provided\"}\n"},"graphqlErrors":null}
exit status 1
```

- Fixes incorrect interface switch from the previous PR for the TOTP manager
- Adds a config setting for the max cookie age