### PR TITLE
breaking: remove default to allow for inheritence

### DIFF
--- a/providers/github/config.go
+++ b/providers/github/config.go
@@ -7,7 +7,7 @@ type ProviderConfig struct {
 	// ClientSecret is the secret for the GitHub oauth2 client
 	ClientSecret string `json:"clientSecret" koanf:"clientSecret" jsonschema:"required" sensitive:"true"`
 	// ClientEndpoint is the endpoint for the GitHub oauth2 client
-	ClientEndpoint string `json:"clientEndpoint" koanf:"clientEndpoint" default:"http://localhost:17608" domain:"inherit" domainPrefix:"https://api"`
+	ClientEndpoint string `json:"clientEndpoint" koanf:"clientEndpoint" domain:"inherit" domainPrefix:"https://api"`
 	// Scopes are the scopes that the GitHub oauth2 client will request
 	Scopes []string `json:"scopes" koanf:"scopes" jsonschema:"required"`
 	// RedirectURL is the URL that the GitHub oauth2 client will redirect to after authentication with Github

--- a/providers/google/config.go
+++ b/providers/google/config.go
@@ -7,7 +7,7 @@ type ProviderConfig struct {
 	// ClientSecret is the secret for the Google oauth2 client
 	ClientSecret string `json:"clientSecret" koanf:"clientSecret" jsonschema:"required" sensitive:"true"`
 	// ClientEndpoint is the endpoint for the Google oauth2 client
-	ClientEndpoint string `json:"clientEndpoint" koanf:"clientEndpoint" default:"http://localhost:17608" domain:"inherit" domainPrefix:"https://api"`
+	ClientEndpoint string `json:"clientEndpoint" koanf:"clientEndpoint" domain:"inherit" domainPrefix:"https://api"`
 	// Scopes are the scopes that the Google oauth2 client will request
 	Scopes []string `json:"scopes" koanf:"scopes" jsonschema:"required"`
 	// RedirectURL is the URL that the Google oauth2 client will redirect to after authentication with Google

--- a/providers/webauthn/config.go
+++ b/providers/webauthn/config.go
@@ -16,13 +16,13 @@ type ProviderConfig struct {
 	// Enabled is the provider enabled
 	Enabled bool `json:"enabled" koanf:"enabled" default:"true"`
 	// DisplayName is the site display name
-	DisplayName string `json:"displayName" koanf:"displayName" jsonschema:"required" default:""`
+	DisplayName string `json:"displayName" koanf:"displayName" jsonschema:"required"`
 	// RelyingPartyID is the relying party identifier
 	// set to localhost for development, no port
-	RelyingPartyID string `json:"relyingPartyId" koanf:"relyingPartyId" jsonschema:"required" default:"localhost" domain:"inherit"`
+	RelyingPartyID string `json:"relyingPartyId" koanf:"relyingPartyId" jsonschema:"required" domain:"inherit"`
 	// RequestOrigins the origin domain(s) for authentication requests
 	// include the scheme and port
-	RequestOrigins []string `json:"requestOrigins" koanf:"requestOrigins" jsonschema:"required"  default:"[http://localhost:3001]" domain:"inherit" domainPrefix:"https://console"`
+	RequestOrigins []string `json:"requestOrigins" koanf:"requestOrigins" jsonschema:"required" domain:"inherit" domainPrefix:"https://console"`
 	// MaxDevices is the maximum number of devices that can be associated with a user
 	MaxDevices int `json:"maxDevices" koanf:"maxDevices" default:"10"`
 	// EnforceTimeout at the Relying Party / Server. This means if enabled and the user takes too long that even if the browser does not

--- a/sessions/sessions.go
+++ b/sessions/sessions.go
@@ -14,7 +14,7 @@ type Config struct {
 	// EncryptionKey must be a 16, 32, or 64 character string used to encode the cookie
 	EncryptionKey string `json:"encryptionKey" koanf:"encryptionKey" default:"encryptionsecret"`
 	// Domain is the domain for the cookie, leave empty to use the default value of the server
-	Domain string `json:"domain" koanf:"domain" default:"" domain:"inherit"`
+	Domain string `json:"domain" koanf:"domain" domain:"inherit"`
 	// MaxAge is the maximum age of the session cookie in seconds. After this time, the cookie will be invalidated
 	MaxAge int `json:"maxAge" koanf:"maxAge" default:"3600"` // 1 hour by default in seconds
 	// Secure indicates whether the session cookie should only be sent over HTTPS

--- a/tokens/config.go
+++ b/tokens/config.go
@@ -7,11 +7,11 @@ type Config struct {
 	// KID represents the Key ID used in the configuration.
 	KID string `json:"kid" koanf:"kid" jsonschema:"required"`
 	// Audience represents the target audience for the tokens.
-	Audience string `json:"audience" koanf:"audience" jsonschema:"required" default:"https://theopenlane.io" domain:"inherit" domainPrefix:"https://api"`
+	Audience string `json:"audience" koanf:"audience" jsonschema:"required" domain:"inherit" domainPrefix:"https://api"`
 	// RefreshAudience represents the audience for refreshing tokens.
 	RefreshAudience string `json:"refreshAudience" koanf:"refreshAudience" domain:"inherit" domainPrefix:"https://api"`
 	// Issuer represents the issuer of the tokens
-	Issuer string `json:"issuer" koanf:"issuer" jsonschema:"required" default:"https://auth.theopenlane.io" domain:"inherit" domainPrefix:"https://api"`
+	Issuer string `json:"issuer" koanf:"issuer" jsonschema:"required" domain:"inherit" domainPrefix:"https://api"`
 	// AccessDuration represents the duration of the access token is valid for
 	AccessDuration time.Duration `json:"accessDuration" koanf:"accessDuration" default:"1h"`
 	// RefreshDuration represents the duration of the refresh token is valid for
@@ -19,7 +19,7 @@ type Config struct {
 	// RefreshOverlap represents the overlap time for a refresh and access token
 	RefreshOverlap time.Duration `json:"refreshOverlap" koanf:"refreshOverlap" default:"-15m" `
 	// JWKSEndpoint represents the endpoint for the JSON Web Key Set
-	JWKSEndpoint string `json:"jwksEndpoint" koanf:"jwksEndpoint" default:"https://api.theopenlane.io/.well-known/jwks.json" domain:"inherit" domainPrefix:"https://api" domainSuffix:"/.well-known/jwks.json"`
+	JWKSEndpoint string `json:"jwksEndpoint" koanf:"jwksEndpoint" domain:"inherit" domainPrefix:"https://api" domainSuffix:"/.well-known/jwks.json"`
 	// Keys represents the key pairs used for signing the tokens
 	Keys map[string]string `json:"keys" koanf:"keys" jsonschema:"required"`
 	// GenerateKeys is a boolean to determine if the keys should be generated

--- a/totp/config.go
+++ b/totp/config.go
@@ -13,7 +13,7 @@ type Config struct {
 	// CodeLength is the length of the OTP code
 	CodeLength int `json:"codeLength" koanf:"codeLength" default:"6"`
 	// Issuer is the issuer for TOTP codes
-	Issuer string `json:"issuer" koanf:"issuer" default:"" domain:"inherit"`
+	Issuer string `json:"issuer" koanf:"issuer" domain:"inherit"`
 	// WithRedis configures the service with a redis client
 	WithRedis bool `json:"redis" koanf:"redis" default:"true"`
 	// Secret stores a versioned secret key for cryptography functions


### PR DESCRIPTION
having the defaults in here, means they get set as defaults in the `values.yaml` and we can't use the inherit feature. 