### PR TITLE
fix: replaced session id with userid which the CreateAndStoreSession func was expecting

### DIFF
--- a/sessions/middleware.go
+++ b/sessions/middleware.go
@@ -192,7 +192,7 @@ func LoadAndSaveWithConfig(config SessionConfig) echo.MiddlewareFunc {
 				}
 
 				// refresh and save session cookie
-				ctx, err := config.CreateAndStoreSession(c.Request().Context(), c.Response().Writer, sessionID)
+				ctx, err := config.CreateAndStoreSession(c.Request().Context(), c.Response().Writer, userID)
 				if err != nil {
 					log.Error().Err(err).Msg("unable to create and store new session")
 


### PR DESCRIPTION
closes #491 

in sessions/middleware.go -- CreateAndStoreSessionI() was expecting userID but it was provided sessionID instead , fixed it .