### PR TITLE
fix: use same caps as real system admin

### DIFF
--- a/auth/test_tools.go
+++ b/auth/test_tools.go
@@ -64,9 +64,9 @@ func NewTestContextWithValidUser(subject string, opts ...CallerOption) context.C
 }
 
 // NewTestContextForSystemAdmin creates a context with system admin capabilities set for testing purposes only.
-// Capabilities match NewSystemAdminCaller: CapBypassOrgFilter, CapBypassFGA, CapBypassFeatureCheck, CapInternalOperation, CapSystemAdmin.
+// Capabilities match NewSystemAdminCaller: CapBypassOrgFilter, CapSystemAdmin.
 func NewTestContextForSystemAdmin(sub, orgID string, opts ...CallerOption) context.Context {
-	caps := CapBypassOrgFilter | CapBypassFGA | CapBypassFeatureCheck | CapInternalOperation | CapSystemAdmin
+	caps := CapBypassOrgFilter | CapSystemAdmin
 	return NewTestContextWithOrgID(sub, orgID, append([]CallerOption{WithCapabilities(caps)}, opts...)...)
 }
 


### PR DESCRIPTION
This matches the prod path:

```
func capabilitiesFor(isAdmin bool) auth.Capability {
	if isAdmin {
		return auth.CapSystemAdmin | auth.CapBypassOrgFilter
	}

	return 0
}
```