### PR TITLE
Fix Logout Path, enable logout handler capabilities

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -113,10 +113,13 @@ func SetAuthCookies(w http.ResponseWriter, accessToken, refreshToken string, c s
 	sessions.SetCookie(w, refreshToken, RefreshTokenCookie, c)
 }
 
-// ClearAuthCookies is a helper function to clear authentication cookies on a echo
-// request to effectively logger out a user.
-func ClearAuthCookies(w http.ResponseWriter) {
-	sessions.RemoveCookies(w, *sessions.DefaultCookieConfig, AccessTokenCookie, RefreshTokenCookie)
+// ClearAuthCookies clears the access and refresh token cookies to effectively log out a user. The
+// supplied CookieConfig must match the one the cookies were set with via SetAuthCookies (domain,
+// path, secure, samesite); otherwise the browser will not match the expiry cookie and the original
+// cookies will persist. Pass the same SessionConfig.CookieConfig used at login rather than a global
+// default.
+func ClearAuthCookies(w http.ResponseWriter, c sessions.CookieConfig) {
+	sessions.RemoveCookies(w, c, AccessTokenCookie, RefreshTokenCookie)
 }
 
 // CookieExpired checks to see if a cookie is expired

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -259,7 +259,7 @@ func TestClearAuthCookies(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(_ *testing.T) {
-			auth.ClearAuthCookies(tc.ctx.Response().Writer)
+			auth.ClearAuthCookies(tc.ctx.Response().Writer, *sessions.DebugOnlyCookieConfig)
 		})
 	}
 }

--- a/sessions/cookiestore.go
+++ b/sessions/cookiestore.go
@@ -25,7 +25,8 @@ type Store[T any] interface {
 	Get(req *http.Request, name string) (*Session[T], error)
 	// Save writes a Session to the ResponseWriter
 	Save(w http.ResponseWriter, session *Session[T]) error
-	// Destroy removes (expires) a named Session
+	// Destroy expires the named session cookie on the response. This only clears the client cookie
+	// and does not remove any persisted session; use SessionConfig.DestroySession on logout
 	Destroy(w http.ResponseWriter, name string)
 	// GetSessionIDFromCookie returns the key, which should be the sessionID, in the map
 	GetSessionIDFromCookie(sess *Session[T]) string
@@ -115,14 +116,19 @@ func (s *cookieStore[T]) Save(w http.ResponseWriter, session *Session[T]) error 
 	return nil
 }
 
+// EncodeCookie encodes the session values into a cookie value string
 func (s *cookieStore[T]) EncodeCookie(session *Session[T]) (string, error) {
 	return securecookie.EncodeMulti(session.Name(), &session.values, s.codecs...)
 }
 
-// Destroy deletes the Session with the given name by issuing an expired
-// session cookie with the same name.
+// Destroy expires the session cookie with the given name by issuing an expired cookie. It only
+// clears the client cookie and does not remove any persisted session; use
+// SessionConfig.DestroySession to also delete the session from the backing store on logout.
 func (s *cookieStore[T]) Destroy(w http.ResponseWriter, name string) {
-	http.SetCookie(w, NewCookie(name, "", &CookieConfig{MaxAge: -1, Path: s.config.Path}))
+	// reuse the full store config so the deletion cookie matches the original on Domain, Path,
+	// Secure, and SameSite; a deletion cookie that omits the Domain will not match a cookie that was
+	// set with one and the browser will keep it
+	RemoveCookie(w, name, *s.config)
 }
 
 // NewSessionCookie creates a cookie from a session id

--- a/sessions/destroysession_test.go
+++ b/sessions/destroysession_test.go
@@ -56,7 +56,7 @@ func requestWithSessionCookie(t *testing.T, sc sessions.SessionConfig, userID st
 	_, err := sc.CreateAndStoreSession(context.Background(), createRec, userID)
 	require.NoError(t, err)
 
-	req := httptest.NewRequest(http.MethodPost, "/logout", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/logout", nil)
 	for _, c := range createRec.Result().Cookies() {
 		req.AddCookie(c)
 	}
@@ -103,7 +103,7 @@ func TestDestroySession(t *testing.T) {
 		sc, _, mr := newDestroyTestConfig(t)
 		defer mr.Close()
 
-		req := httptest.NewRequest(http.MethodPost, "/logout", nil)
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/logout", nil)
 		rec := httptest.NewRecorder()
 
 		err := sc.DestroySession(ctx, rec, req)
@@ -114,8 +114,14 @@ func TestDestroySession(t *testing.T) {
 		sc, _, mr := newDestroyTestConfig(t)
 		defer mr.Close()
 
-		req := httptest.NewRequest(http.MethodPost, "/logout", nil)
-		req.AddCookie(&http.Cookie{Name: sc.CookieConfig.Name, Value: "not-a-valid-encoded-cookie"})
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/logout", nil)
+		req.AddCookie(&http.Cookie{
+			Name:     sc.CookieConfig.Name,
+			Value:    "not-a-valid-encoded-cookie",
+			Secure:   true,
+			HttpOnly: true,
+			SameSite: http.SameSiteStrictMode,
+		})
 
 		rec := httptest.NewRecorder()
 
@@ -158,7 +164,7 @@ func TestDestroySession(t *testing.T) {
 		session.Set(sessions.GenerateSessionID(), map[string]any{sessions.UserIDKey: "user-x"})
 		require.NoError(t, session.Save(setRec))
 
-		req := httptest.NewRequest(http.MethodPost, "/logout", nil)
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/logout", nil)
 		for _, c := range setRec.Result().Cookies() {
 			req.AddCookie(c)
 		}

--- a/sessions/destroysession_test.go
+++ b/sessions/destroysession_test.go
@@ -1,0 +1,235 @@
+package sessions_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/theopenlane/iam/sessions"
+)
+
+// errDeleteSession simulates a backing-store failure when deleting a persisted session
+var errDeleteSession = errors.New("delete failed")
+
+// failingDeleteStore wraps a PersistentStore but always fails DeleteSession, used to exercise the
+// error path of DestroySession
+type failingDeleteStore struct {
+	sessions.PersistentStore
+}
+
+// DeleteSession always returns an error
+func (failingDeleteStore) DeleteSession(context.Context, string) error {
+	return errDeleteSession
+}
+
+// newDestroyTestConfig builds a redis-backed session config sharing a single named cookie config
+// between the cookie store and the session config, mirroring how the server wires sessions
+func newDestroyTestConfig(t *testing.T) (sessions.SessionConfig, sessions.Store[map[string]any], *miniredis.Miniredis) {
+	t.Helper()
+
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+
+	rc := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	cc := sessions.DebugOnlyCookieConfig
+	sm := sessions.NewCookieStore[map[string]any](cc, []byte("my-signing-secret"), []byte("encryptionsecret"))
+
+	sc := sessions.NewSessionConfig(sm, sessions.WithPersistence(rc))
+	sc.CookieConfig = cc
+
+	return sc, sm, mr
+}
+
+// requestWithSessionCookie creates a session in the store and returns a request carrying its cookie
+func requestWithSessionCookie(t *testing.T, sc sessions.SessionConfig, userID string) *http.Request {
+	t.Helper()
+
+	createRec := httptest.NewRecorder()
+	_, err := sc.CreateAndStoreSession(context.Background(), createRec, userID)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/logout", nil)
+	for _, c := range createRec.Result().Cookies() {
+		req.AddCookie(c)
+	}
+
+	return req
+}
+
+func TestDestroySession(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("removes the persisted session and expires the cookie", func(t *testing.T) {
+		sc, _, mr := newDestroyTestConfig(t)
+		defer mr.Close()
+
+		req := requestWithSessionCookie(t, sc, "user-123")
+
+		session, err := sc.SessionManager.Get(req, sc.CookieConfig.Name)
+		require.NoError(t, err)
+
+		sessionID := sc.SessionManager.GetSessionIDFromCookie(session)
+		require.NotEmpty(t, sessionID)
+
+		exists, err := sc.RedisStore.Exists(ctx, sessionID)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), exists)
+
+		destroyRec := httptest.NewRecorder()
+		err = sc.DestroySession(ctx, destroyRec, req)
+		require.NoError(t, err)
+
+		// the persisted session is gone
+		exists, err = sc.RedisStore.Exists(ctx, sessionID)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), exists)
+
+		// the cookie is expired on the response
+		cookies := destroyRec.Result().Cookies()
+		require.Len(t, cookies, 1)
+		assert.Equal(t, sc.CookieConfig.Name, cookies[0].Name)
+		assert.Equal(t, -1, cookies[0].MaxAge)
+	})
+
+	t.Run("no session cookie is a no-op that still returns nil", func(t *testing.T) {
+		sc, _, mr := newDestroyTestConfig(t)
+		defer mr.Close()
+
+		req := httptest.NewRequest(http.MethodPost, "/logout", nil)
+		rec := httptest.NewRecorder()
+
+		err := sc.DestroySession(ctx, rec, req)
+		assert.NoError(t, err)
+	})
+
+	t.Run("malformed session cookie is a no-op that still returns nil", func(t *testing.T) {
+		sc, _, mr := newDestroyTestConfig(t)
+		defer mr.Close()
+
+		req := httptest.NewRequest(http.MethodPost, "/logout", nil)
+		req.AddCookie(&http.Cookie{Name: sc.CookieConfig.Name, Value: "not-a-valid-encoded-cookie"})
+
+		rec := httptest.NewRecorder()
+
+		err := sc.DestroySession(ctx, rec, req)
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns an error and keeps the cookie when the persisted session cannot be deleted", func(t *testing.T) {
+		sc, _, mr := newDestroyTestConfig(t)
+		defer mr.Close()
+
+		req := requestWithSessionCookie(t, sc, "user-err")
+
+		// swap in a store whose DeleteSession always fails
+		failing := sc
+		failing.RedisStore = failingDeleteStore{PersistentStore: sc.RedisStore}
+
+		destroyRec := httptest.NewRecorder()
+		err := failing.DestroySession(ctx, destroyRec, req)
+
+		// the failure is surfaced, not swallowed
+		assert.ErrorIs(t, err, errDeleteSession)
+
+		// the cookie is NOT expired, so the client is forced to retry rather than believe it logged out
+		assert.Empty(t, destroyRec.Result().Cookies())
+	})
+
+	t.Run("expires the cookie without a persistent store", func(t *testing.T) {
+		cc := sessions.DebugOnlyCookieConfig
+		sm := sessions.NewCookieStore[map[string]any](cc, []byte("my-signing-secret"), []byte("encryptionsecret"))
+
+		// no WithPersistence, so RedisStore is nil
+		sc := sessions.NewSessionConfig(sm)
+		sc.CookieConfig = cc
+		require.Nil(t, sc.RedisStore)
+
+		// manually create a session cookie using the same store
+		setRec := httptest.NewRecorder()
+		session := sm.New(cc.Name)
+		session.Set(sessions.GenerateSessionID(), map[string]any{sessions.UserIDKey: "user-x"})
+		require.NoError(t, session.Save(setRec))
+
+		req := httptest.NewRequest(http.MethodPost, "/logout", nil)
+		for _, c := range setRec.Result().Cookies() {
+			req.AddCookie(c)
+		}
+
+		destroyRec := httptest.NewRecorder()
+		err := sc.DestroySession(ctx, destroyRec, req)
+		assert.NoError(t, err)
+
+		cookies := destroyRec.Result().Cookies()
+		require.Len(t, cookies, 1)
+		assert.Equal(t, -1, cookies[0].MaxAge)
+	})
+}
+
+// TestCookieStoreDestroy covers the fix that makes Store.Destroy build the deletion cookie from the
+// full store config rather than only the path, so it reliably matches the original cookie
+func TestCookieStoreDestroy(t *testing.T) {
+	t.Run("replaces the original cookie with an expired one matching its identity", func(t *testing.T) {
+		cfg := &sessions.CookieConfig{
+			Name:     "sess",
+			Domain:   "example.com",
+			Path:     "/app",
+			Secure:   true,
+			HTTPOnly: true,
+			SameSite: http.SameSiteStrictMode,
+		}
+		cs := sessions.NewCookieStore[map[string]any](cfg, []byte("my-signing-secret"), []byte("encryptionsecret"))
+
+		// set a real session cookie and capture the original that we intend to remove
+		setRec := httptest.NewRecorder()
+		session := cs.New(cfg.Name)
+		session.Set(sessions.GenerateSessionID(), map[string]any{sessions.UserIDKey: "user-x"})
+		require.NoError(t, session.Save(setRec))
+
+		setCookies := setRec.Result().Cookies()
+		require.Len(t, setCookies, 1)
+
+		original := setCookies[0]
+		require.NotEmpty(t, original.Value)
+		require.Equal(t, "example.com", original.Domain) // the attribute the buggy deletion dropped
+
+		// destroy and capture the deletion cookie
+		destroyRec := httptest.NewRecorder()
+		cs.Destroy(destroyRec, cfg.Name)
+
+		delCookies := destroyRec.Result().Cookies()
+		require.Len(t, delCookies, 1)
+
+		deletion := delCookies[0]
+
+		// the deletion cookie must share the original's identity (name+domain+path) and security
+		// attributes, otherwise the browser stores a second, non-matching cookie and keeps the original.
+		// This is exactly what the old Destroy did by dropping Domain/Secure/SameSite
+		assert.Equal(t, original.Name, deletion.Name)
+		assert.Equal(t, original.Domain, deletion.Domain)
+		assert.Equal(t, original.Path, deletion.Path)
+		assert.Equal(t, original.Secure, deletion.Secure)
+		assert.Equal(t, original.SameSite, deletion.SameSite)
+
+		// and it must actually expire and empty the value so the original is replaced, not duplicated
+		assert.Equal(t, -1, deletion.MaxAge)
+		assert.Empty(t, deletion.Value)
+	})
+
+	t.Run("sets no cookie when no name can be resolved", func(t *testing.T) {
+		cfg := &sessions.CookieConfig{Path: "/"} // empty Name
+		cs := sessions.NewCookieStore[map[string]any](cfg, []byte("my-signing-secret"), []byte("encryptionsecret"))
+
+		rec := httptest.NewRecorder()
+		cs.Destroy(rec, "") // empty name and empty config name resolves to no cookie
+
+		assert.Empty(t, rec.Result().Cookies())
+	})
+}

--- a/sessions/middleware.go
+++ b/sessions/middleware.go
@@ -2,6 +2,7 @@ package sessions
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"slices"
 	"time"
@@ -113,6 +114,43 @@ func (sc *SessionConfig) SaveAndStoreSession(ctx context.Context, w http.Respons
 	}
 
 	return c, nil
+}
+
+// DestroySession is the inverse of CreateAndStoreSession: it removes the session presented on the
+// request by deleting the persisted session from the backing store (e.g. redis) and expiring the
+// session cookie on the response. This is the correct way to invalidate a session on logout, since
+// the cookie-only Store.Destroy and Session.Destroy leave the persisted session in place.
+//
+// A request that carries no resolvable session is treated as already destroyed: the cookie is still
+// expired and nil is returned, which keeps logout idempotent. A cookie that is present but cannot be
+// decoded is anomalous (tampering, corruption, or a dropped signing key); it cannot identify a
+// persisted session to delete, so it is logged and the bad cookie is cleared, but it is not treated
+// as a hard failure since it is not retryable and decode errors can occur benignly during key
+// rotation. An error is only returned when an identified, persisted session could not be deleted, so
+// callers can avoid reporting a logout that did not take effect
+func (sc *SessionConfig) DestroySession(ctx context.Context, w http.ResponseWriter, req *http.Request) error {
+	session, err := sc.SessionManager.Get(req, sc.CookieConfig.Name)
+	if err != nil {
+		// a missing cookie is normal; a cookie that is present but undecodable is anomalous and logged
+		if !errors.Is(err, http.ErrNoCookie) {
+			log.Warn().Err(err).Msg("could not decode session cookie on destroy; clearing it")
+		}
+
+		// no resolvable session to remove server-side, but still expire whatever cookie was presented
+		RemoveCookie(w, sc.CookieConfig.Name, *sc.CookieConfig)
+
+		return nil
+	}
+
+	if sessionID := sc.SessionManager.GetSessionIDFromCookie(session); sessionID != "" && sc.RedisStore != nil {
+		if err := sc.RedisStore.DeleteSession(ctx, sessionID); err != nil {
+			return err
+		}
+	}
+
+	RemoveCookie(w, sc.CookieConfig.Name, *sc.CookieConfig)
+
+	return nil
 }
 
 // LoadAndSave is a middleware function that loads and saves session data using a

--- a/sessions/sessions.go
+++ b/sessions/sessions.go
@@ -83,8 +83,10 @@ func (s *Session[T]) Save(w http.ResponseWriter) error {
 	return s.store.Save(w, s)
 }
 
-// Destroy destroys the session. Identical to calling
-// store.Destroy(w, session.name).
+// Destroy expires the session cookie on the response. Identical to calling
+// store.Destroy(w, session.name). This only clears the client cookie and does not remove any
+// persisted session; use SessionConfig.DestroySession to also delete the session from the backing
+// store on logout.
 func (s *Session[T]) Destroy(w http.ResponseWriter) {
 	s.store.Destroy(w, s.name)
 }

--- a/tokens/blacklist_test.go
+++ b/tokens/blacklist_test.go
@@ -506,17 +506,18 @@ func TestGeneralTokenBlacklist(t *testing.T) {
 		verifiedClaims, err := tmNoBlacklist.VerifyWithContext(ctx, tokenString)
 		assert.NoError(t, err)
 
-		// Try to revoke (should be no-op)
+		// Try to revoke; without a functional blacklist this surfaces an error rather than
+		// silently succeeding, but the token remains valid since the revocation had no effect
 		err = tmNoBlacklist.RevokeToken(ctx, verifiedClaims.ID, 30*time.Minute)
-		assert.NoError(t, err)
+		assert.ErrorIs(t, err, tokens.ErrRevocationNotConfigured)
 
 		// Token should still work since no blacklist
 		_, err = tmNoBlacklist.VerifyWithContext(ctx, tokenString)
 		assert.NoError(t, err)
 
-		// Try to suspend user (should be no-op)
+		// Try to suspend user; same as revoke, this surfaces an error without a functional blacklist
 		err = tmNoBlacklist.SuspendUser(ctx, "user-no-blacklist", 30*time.Minute)
-		assert.NoError(t, err)
+		assert.ErrorIs(t, err, tokens.ErrRevocationNotConfigured)
 
 		// Token should still work since no blacklist
 		_, err = tmNoBlacklist.VerifyWithContext(ctx, tokenString)

--- a/tokens/errors.go
+++ b/tokens/errors.go
@@ -142,6 +142,9 @@ var (
 	ErrInvalidTokenID = errors.New("invalid token ID")
 	// ErrKeyLifecycleNotEnabled is returned when key lifecycle management is not enabled
 	ErrKeyLifecycleNotEnabled = errors.New("key lifecycle management not enabled")
+	// ErrRevocationNotConfigured is returned when a revocation or suspension operation is attempted
+	// while only the no-op blacklist is installed, meaning the operation has no effect
+	ErrRevocationNotConfigured = errors.New("token revocation is not configured: no functional blacklist is installed")
 )
 
 // The errors that might occur when parsing and validating a token

--- a/tokens/jwks.go
+++ b/tokens/jwks.go
@@ -38,7 +38,7 @@ func NewJWKSValidator(keys jwk.Set, audience, issuer string) *JWKSValidator {
 // verification. Without it the JWKS validator performs signature and claim checks only and
 // cannot honor token or user revocation
 func (v *JWKSValidator) WithBlacklist(blacklist TokenBlacklist) *JWKSValidator {
-	v.validator.blacklist = blacklist
+	v.blacklist = blacklist
 
 	return v
 }
@@ -114,7 +114,7 @@ func NewCachedJWKSValidator(cache *jwk.Cache, endpoint, audience, issuer string)
 // WithBlacklist attaches a token blacklist to the cached validator so the per-request verify
 // path consults revocation state
 func (v *CachedJWKSValidator) WithBlacklist(blacklist TokenBlacklist) *CachedJWKSValidator {
-	v.validator.blacklist = blacklist
+	v.blacklist = blacklist
 
 	return v
 }

--- a/tokens/jwks.go
+++ b/tokens/jwks.go
@@ -3,6 +3,7 @@ package tokens
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/lestrrat-go/jwx/v3/jwk"
@@ -33,6 +34,15 @@ func NewJWKSValidator(keys jwk.Set, audience, issuer string) *JWKSValidator {
 	return validator
 }
 
+// WithBlacklist attaches a token blacklist so the validator consults revocation state during
+// verification. Without it the JWKS validator performs signature and claim checks only and
+// cannot honor token or user revocation
+func (v *JWKSValidator) WithBlacklist(blacklist TokenBlacklist) *JWKSValidator {
+	v.validator.blacklist = blacklist
+
+	return v
+}
+
 // keyFunc is a jwt.KeyFunc that selects the RSA public key from the list of managed
 // internal keys based on the kid in the token header
 func (v *JWKSValidator) keyFunc(token *jwt.Token) (publicKey any, err error) {
@@ -49,16 +59,8 @@ func (v *JWKSValidator) keyFunc(token *jwt.Token) (publicKey any, err error) {
 
 	// Per JWT security notice: do not forget to validate alg is expected
 	method := token.Method.Alg()
-	allowed := false
 
-	for _, allowedAlg := range allowedAlgorithms {
-		if method == allowedAlg {
-			allowed = true
-			break
-		}
-	}
-
-	if !allowed {
+	if !slices.Contains(allowedAlgorithms, method) {
 		return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"]) //nolint:err113
 	}
 
@@ -109,6 +111,14 @@ func NewCachedJWKSValidator(cache *jwk.Cache, endpoint, audience, issuer string)
 	return validator, nil
 }
 
+// WithBlacklist attaches a token blacklist to the cached validator so the per-request verify
+// path consults revocation state
+func (v *CachedJWKSValidator) WithBlacklist(blacklist TokenBlacklist) *CachedJWKSValidator {
+	v.validator.blacklist = blacklist
+
+	return v
+}
+
 // Refresh method in the `CachedJWKSValidator` struct is responsible for refreshing the JWKS
 // (JSON Web Key Set) cache. It takes in a `context.Context` as a parameter and returns an error if
 // the refresh process fails
@@ -123,7 +133,7 @@ func (v *CachedJWKSValidator) Refresh(ctx context.Context) (err error) {
 // The `func (v *CachedJWKSValidator) keyFunc(token *jwt.Token)` method in the `CachedJWKSValidator`
 // struct is implementing a custom key function for retrieving the public key used to verify the JWT
 // token signature
-func (v *CachedJWKSValidator) keyFunc(token *jwt.Token) (publicKey interface{}, err error) {
+func (v *CachedJWKSValidator) keyFunc(token *jwt.Token) (publicKey any, err error) {
 	if v.keys, err = v.cache.Lookup(context.Background(), v.endpoint); err != nil {
 		return nil, fmt.Errorf("could not retrieve JWKS from cache: %w", err)
 	}

--- a/tokens/revocation_test.go
+++ b/tokens/revocation_test.go
@@ -1,0 +1,156 @@
+package tokens_test
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/theopenlane/iam/tokens"
+)
+
+// revocationTestConfig returns a token manager config suitable for the revocation tests
+func revocationTestConfig() tokens.Config {
+	return tokens.Config{
+		Audience:        "test-audience",
+		Issuer:          "test-issuer",
+		AccessDuration:  1 * time.Hour,
+		RefreshDuration: 2 * time.Hour,
+		RefreshOverlap:  -15 * time.Minute,
+	}
+}
+
+func TestRevocationEnabled(t *testing.T) {
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	conf := revocationTestConfig()
+
+	t.Run("false with default no-op blacklist", func(t *testing.T) {
+		tm, err := tokens.NewWithKey(key, conf)
+		require.NoError(t, err)
+
+		assert.False(t, tm.RevocationEnabled())
+	})
+
+	t.Run("true with a redis blacklist", func(t *testing.T) {
+		mr, err := miniredis.Run()
+		require.NoError(t, err)
+
+		defer mr.Close()
+
+		client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+		defer client.Close()
+
+		tm, err := tokens.NewWithKey(key, conf)
+		require.NoError(t, err)
+
+		tm.WithBlacklist(tokens.NewRedisTokenBlacklist(client, "test:revocation"))
+
+		assert.True(t, tm.RevocationEnabled())
+	})
+}
+
+func TestRevocationMethodsAreNoisyWithoutBlacklist(t *testing.T) {
+	ctx := context.Background()
+
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	tm, err := tokens.NewWithKey(key, revocationTestConfig())
+	require.NoError(t, err)
+
+	// mutations surface ErrRevocationNotConfigured rather than silently succeeding
+	assert.ErrorIs(t, tm.RevokeToken(ctx, "jti-1", time.Hour), tokens.ErrRevocationNotConfigured)
+	assert.ErrorIs(t, tm.RevokeTokenWithTTL(ctx, "jti-1", time.Hour), tokens.ErrRevocationNotConfigured)
+	assert.ErrorIs(t, tm.RevokeImpersonationToken(ctx, "session-1", time.Hour), tokens.ErrRevocationNotConfigured)
+	assert.ErrorIs(t, tm.SuspendUser(ctx, "user-1", time.Hour), tokens.ErrRevocationNotConfigured)
+	assert.ErrorIs(t, tm.SuspendUserWithDuration(ctx, "user-1", time.Hour), tokens.ErrRevocationNotConfigured)
+
+	// reads surface the error and report not-revoked so callers can tell the check was inoperative
+	revoked, err := tm.IsTokenRevoked(ctx, "jti-1")
+	assert.False(t, revoked)
+	assert.ErrorIs(t, err, tokens.ErrRevocationNotConfigured)
+
+	suspended, err := tm.IsUserSuspended(ctx, "user-1")
+	assert.False(t, suspended)
+	assert.ErrorIs(t, err, tokens.ErrRevocationNotConfigured)
+}
+
+// TestJWKSValidatorBlacklist proves the request-path JWKS validator honors revocation only when a
+// blacklist is wired into it, which is the gap the WithBlacklist option closes
+func TestJWKSValidatorBlacklist(t *testing.T) {
+	ctx := context.Background()
+
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+
+	defer mr.Close()
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	conf := revocationTestConfig()
+
+	tm, err := tokens.NewWithKey(key, conf)
+	require.NoError(t, err)
+
+	blacklist := tokens.NewRedisTokenBlacklist(client, "test:jwks")
+	tm.WithBlacklist(blacklist)
+
+	keys, err := tm.Keys()
+	require.NoError(t, err)
+
+	// signTokenWithID signs a fresh access token and returns the signed string and its jwt id
+	signToken := func() (string, string) {
+		jwtToken, err := tm.CreateAccessToken(&tokens.Claims{UserID: "user-123", OrgID: "org-456"})
+		require.NoError(t, err)
+
+		signed, err := tm.Sign(jwtToken)
+		require.NoError(t, err)
+
+		claims, err := tokens.ParseUnverifiedTokenClaims(signed)
+		require.NoError(t, err)
+
+		return signed, claims.ID
+	}
+
+	t.Run("validator without a blacklist cannot honor revocation", func(t *testing.T) {
+		validator := tokens.NewJWKSValidator(keys, conf.Audience, conf.Issuer)
+
+		signed, jti := signToken()
+
+		_, err := validator.VerifyWithContext(ctx, signed)
+		require.NoError(t, err)
+
+		// revoke the token directly on the shared store
+		require.NoError(t, blacklist.Revoke(ctx, jti, 30*time.Minute))
+
+		// without WithBlacklist the validator still accepts the revoked token
+		_, err = validator.VerifyWithContext(ctx, signed)
+		assert.NoError(t, err)
+	})
+
+	t.Run("validator with a blacklist rejects revoked tokens", func(t *testing.T) {
+		validator := tokens.NewJWKSValidator(keys, conf.Audience, conf.Issuer).WithBlacklist(blacklist)
+
+		signed, jti := signToken()
+
+		_, err := validator.VerifyWithContext(ctx, signed)
+		require.NoError(t, err)
+
+		require.NoError(t, blacklist.Revoke(ctx, jti, 30*time.Minute))
+
+		_, err = validator.VerifyWithContext(ctx, signed)
+		assert.ErrorIs(t, err, tokens.ErrTokenInvalid)
+	})
+}

--- a/tokens/tokenmanager.go
+++ b/tokens/tokenmanager.go
@@ -279,31 +279,40 @@ func (tm *TokenManager) ValidateImpersonationToken(ctx context.Context, tokenStr
 	return claims, nil
 }
 
-// RevokeImpersonationToken revokes an impersonation token by adding it to the blacklist
+// RevokeImpersonationToken revokes an impersonation token by adding it to the blacklist. It returns
+// ErrRevocationNotConfigured, and logs a warning, when no functional blacklist is installed so the
+// caller is not misled into believing the session was revoked
 func (tm *TokenManager) RevokeImpersonationToken(ctx context.Context, sessionID string, ttl time.Duration) error {
-	if tm.blacklist == nil {
-		// No blacklist configured, tokens cannot be revoked
-		return nil
+	if !tm.RevocationEnabled() {
+		log.Warn().Str("session_id", sessionID).Msg("impersonation token revocation requested but no functional blacklist is configured; the session remains valid until it expires")
+
+		return ErrRevocationNotConfigured
 	}
 
 	return tm.blacklist.Revoke(ctx, sessionID, ttl)
 }
 
-// RevokeToken revokes a JWT token by its ID
+// RevokeToken revokes a JWT token by its ID. It returns ErrRevocationNotConfigured, and logs a
+// warning, when no functional blacklist is installed so the caller is not misled into believing the
+// token was revoked
 func (tm *TokenManager) RevokeToken(ctx context.Context, tokenID string, ttl time.Duration) error {
-	if tm.blacklist == nil {
-		// No blacklist configured, tokens cannot be revoked
-		return nil
+	if !tm.RevocationEnabled() {
+		log.Warn().Str("token_id", tokenID).Msg("token revocation requested but no functional blacklist is configured; the token remains valid until it expires")
+
+		return ErrRevocationNotConfigured
 	}
 
 	return tm.blacklist.Revoke(ctx, tokenID, ttl)
 }
 
-// SuspendUser suspends all tokens for a user
+// SuspendUser suspends all tokens for a user. It returns ErrRevocationNotConfigured, and logs a
+// warning, when no functional blacklist is installed so the caller is not misled into believing the
+// user was suspended
 func (tm *TokenManager) SuspendUser(ctx context.Context, userID string, ttl time.Duration) error {
-	if tm.blacklist == nil {
-		// No blacklist configured, users cannot be suspended
-		return nil
+	if !tm.RevocationEnabled() {
+		log.Warn().Str("user_id", userID).Msg("user suspension requested but no functional blacklist is configured; the user's tokens remain valid until they expire")
+
+		return ErrRevocationNotConfigured
 	}
 
 	return tm.blacklist.RevokeAllForUser(ctx, userID, ttl)
@@ -314,10 +323,27 @@ func (tm *TokenManager) GetBlacklist() TokenBlacklist {
 	return tm.blacklist
 }
 
-// IsUserSuspended checks if a user is currently suspended
-func (tm *TokenManager) IsUserSuspended(ctx context.Context, userID string) (bool, error) {
+// RevocationEnabled reports whether a functional token blacklist is configured. It returns false
+// when the no-op blacklist is installed, in which case RevokeToken, SuspendUser, and
+// RevokeImpersonationToken silently have no effect and IsRevoked always reports not revoked
+func (tm *TokenManager) RevocationEnabled() bool {
 	if tm.blacklist == nil {
-		return false, nil
+		return false
+	}
+
+	_, isNoOp := tm.blacklist.(*NoOpTokenBlacklist)
+
+	return !isNoOp
+}
+
+// IsUserSuspended checks if a user is currently suspended. It returns ErrRevocationNotConfigured,
+// and logs a warning, when no functional blacklist is installed so callers can distinguish a
+// genuine "not suspended" result from an inoperative check
+func (tm *TokenManager) IsUserSuspended(ctx context.Context, userID string) (bool, error) {
+	if !tm.RevocationEnabled() {
+		log.Warn().Str("user_id", userID).Msg("user suspension check requested but no functional blacklist is configured; reporting user as not suspended")
+
+		return false, ErrRevocationNotConfigured
 	}
 
 	return tm.blacklist.IsUserRevoked(ctx, userID)
@@ -343,10 +369,14 @@ func (tm *TokenManager) GetUserSuspensionStatus(ctx context.Context, userID stri
 	}, nil
 }
 
-// IsTokenRevoked checks if a specific token (by JWT ID) has been revoked
+// IsTokenRevoked checks if a specific token (by JWT ID) has been revoked. It returns
+// ErrRevocationNotConfigured, and logs a warning, when no functional blacklist is installed so
+// callers can distinguish a genuine "not revoked" result from an inoperative check
 func (tm *TokenManager) IsTokenRevoked(ctx context.Context, tokenID string) (bool, error) {
-	if tm.blacklist == nil {
-		return false, nil
+	if !tm.RevocationEnabled() {
+		log.Warn().Str("token_id", tokenID).Msg("token revocation check requested but no functional blacklist is configured; reporting token as not revoked")
+
+		return false, ErrRevocationNotConfigured
 	}
 
 	return tm.blacklist.IsRevoked(ctx, tokenID)

--- a/tokens/tokenmanager_blacklist_test.go
+++ b/tokens/tokenmanager_blacklist_test.go
@@ -105,9 +105,10 @@ func TestTokenManagerWithBlacklist(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotEmpty(t, claims.SessionID)
 
-		// Try to revoke (should be no-op with no blacklist)
+		// Try to revoke without a functional blacklist; this now surfaces an error rather than
+		// silently succeeding so callers are not misled into believing the session was revoked
 		err = tmNoBlacklist.RevokeImpersonationToken(ctx, claims.SessionID, 30*time.Minute)
-		assert.NoError(t, err) // Should not error
+		assert.ErrorIs(t, err, tokens.ErrRevocationNotConfigured)
 
 		// Validate again (should still work since no blacklist)
 		_, err = tmNoBlacklist.ValidateImpersonationToken(ctx, tokenString)


### PR DESCRIPTION
Addresses https://github.com/theopenlane/iam/issues/492

- JWT verification now honors token and user revocation on every request, by letting the JWKS validator consult a shared blacklist that was previously never wired in
- revoking a token, revoking an impersonation session, and suspending a user now fail loudly with an error and warning when no functional blacklist is configured, instead of silently reporting success
- logout can now fully invalidate a session through `DestroySession`, deleting the persisted Redis session and expiring its cookie
- `DestroySession` stays idempotent when no session is present, logs anomalous undecodable cookies rather than swallowing them, and surfaces backing-store delete failures so a half-completed logout can't report success
- cookie removal now reliably deletes the original cookie by matching its domain, path, secure, and samesite attributes, where it previously issued a non-matching cookie and left the original in place
- clearing the access and refresh cookies now uses the same config they were set with, so they're actually removed across dev and prod instead of relying on a mutable global default