### PR TITLE
Signing Key Rotation

### DIFF
--- a/tokens/README.md
+++ b/tokens/README.md
@@ -1,6 +1,6 @@
 # Tokens Package
 
-The tokens package provides JWT token creation, signing, and validation using Ed25519 (`EdDSA`).
+The tokens package provides JWT token creation, signing, and validation. Signing keys may be Ed25519 (`EdDSA`) or RSA (`RS256`, `RS384`, `RS512`); the algorithm is inferred from the key material.
 
 ## Architecture
 
@@ -90,6 +90,52 @@ validatedClaims, err := tm.VerifyWithContext(ctx, accessToken)
 err = tm.RevokeToken(ctx, tokenID, ttl)
 ```
 
+## Key Rotation
+
+`SetKeySet` atomically replaces an issuer's key material. Because it swaps the whole set
+under a write lock, the same `Issuer` or `TokenManager` pointer can be rotated while it is
+serving traffic — callers holding the pointer do not need to be rebuilt or re-injected.
+
+`KeySet.Verification` is the important half. Those keys verify but never sign, so a key can
+stop signing and later have its private material deleted while tokens it already signed
+remain valid:
+
+```go
+err := tm.SetKeySet(tokens.KeySet{
+    Signing: map[string]crypto.Signer{
+        "current": currentSigner,
+    },
+    Verification: map[string]crypto.PublicKey{
+        "retired": retiredPublicKey,
+    },
+    KID: "current",
+})
+```
+
+Both kids are published in `Keys()`, so external validators can still resolve `retired`.
+
+Selection rules:
+
+- `KID` must name a key in `Signing`. An unknown `KID` returns `ErrUnknownSigningKey` rather
+  than silently choosing another key.
+- Leaving `KID` empty lets the issuer select from `Signing`, preferring the most recent
+  ULID-formatted kid and otherwise taking the lexicographically last one. Supply `KID`
+  explicitly if your kids are not ULIDs, since neither rule is likely to mean anything for
+  content-derived identifiers such as thumbprints.
+- Only `Signing` is considered for selection, so a key placed in `Verification` can never be
+  promoted back into signing.
+- An empty `Signing` map returns `ErrTokenManagerFailedInit`. A rejected set leaves the
+  issuer untouched.
+
+For incremental changes, `AddKey`, `UseSigningKeyID`, and `RemoveSigningKeyByID` mutate the
+set in place and take the same lock.
+
+## Concurrency
+
+`Issuer` and `TokenManager` are safe for concurrent use. Signing, verification, JWKS
+generation, and key set replacement may all run on different goroutines against the same
+instance.
+
 ## Opaque API Tokens
 
 Personal access tokens and other long-lived API credentials can be issued as opaque strings that never persist the raw secret. Configure a symmetric keyring, generate the token, and store only the derived hash alongside the key version. All key material is supplied declaratively via configuration/environment so deployments stay static—rotations happen by updating secrets and restarting the service, never by calling runtime helpers.
@@ -171,10 +217,12 @@ For convenience a CLI lives at `tokens/examples`. Run it with `go run ./tokens/e
 
 ## Key Material
 
-- PEM files referenced in `tokens.Config.Keys` **must** contain an Ed25519 key
-  pair encoded as PKCS#8 (`PRIVATE KEY`) plus a companion `PUBLIC KEY` block.
-- Existing RSA material must be rotated or regenerated. A simple Go snippet can
-  produce compatible files:
+- PEM files referenced in `tokens.Config.Keys` must contain an Ed25519 or RSA
+  private key encoded as PKCS#8 (`PRIVATE KEY`); PKCS#1 (`RSA PRIVATE KEY`) is
+  also accepted. RSA keys must be at least 2048 bits.
+- A companion `PUBLIC KEY` block is optional. When present it is validated
+  against the private key and a mismatch is an error.
+- A Go snippet to produce an Ed25519 file:
 
   ```go
   package main
@@ -201,36 +249,16 @@ For convenience a CLI lives at `tokens/examples`. Run it with `go run ./tokens/e
   }
   ```
 
-- JWKS responses emitted by `TokenManager.Keys()` advertise `alg=EdDSA`,
-  `kty=OKP`, and `crv=Ed25519`, which is compatible with the lestrrat-go/jwx
-  toolchain used elsewhere in this repository.
-
-## API Changes
-
-### New Architecture
-
-The package now provides:
-
-- **`Issuer`** - New interface for token creation and signing
-  - `NewIssuer(config)` - Create issuer from configuration
-  - `NewIssuerWithKey(key, config)` - Create issuer with single key
-  - `CreateAccessToken(claims)` - Create access token
-  - `CreateRefreshToken(accessToken)` - Create refresh token
-  - `CreateTokens(claims)` - Create both tokens in one call
-  - `Sign(token)` - Sign a token
-  - `Parse(tks)` - Parse without claim validation
-  - `Keys()` - Get JWKS
-
-- **`TokenManager`** - Wraps Issuer, adds validation
-  - Inherits all Issuer methods
-  - Adds `Verify()` and `VerifyWithContext()` for validation
-  - Adds blacklist and replay prevention features
+- JWKS responses emitted by `TokenManager.Keys()` advertise the algorithm matching
+  each key: Ed25519 keys as `alg=EdDSA`, `kty=OKP`, `crv=Ed25519`, and RSA keys as
+  `alg=RS256`, `kty=RSA`. Both are compatible with the lestrrat-go/jwx toolchain
+  used elsewhere in this repository.
 
 ## Signer Helpers
 
 Helper constructors are available when loading keys from files:
 
-- `NewFileSigner(path)` loads an Ed25519 key pair from a PEM file and returns it as a `crypto.Signer`.
+- `NewFileSigner(path)` loads an Ed25519 or RSA private key from a PEM file and returns it as a `crypto.Signer`.
 
 ### Token Blacklist
 
@@ -238,35 +266,3 @@ Allows revoking individual tokens or suspending all tokens for a user. Useful fo
 - Immediate token revocation on logout
 - User account suspension
 - Compromised token mitigation
-
-### Configuration
-
-Enable Redis features by adding the `redis` configuration to your `tokens.Config`:
-
-```go
-import (
-    "github.com/theopenlane/iam/tokens"
-    "github.com/theopenlane/utils/cache"
-)
-
-config := tokens.Config{
-    Audience:        "https://api.example.com",
-    Issuer:          "https://api.example.com",
-    AccessDuration:  1 * time.Hour,
-    RefreshDuration: 2 * time.Hour,
-    RefreshOverlap:  -15 * time.Minute,
-    Keys:            map[string]string{"01ABC": "/path/to/key.pem"},
-    Redis: tokens.RedisConfig{
-        Enabled: true,
-        Config: cache.Config{
-            Enabled:  true,
-            Address:  "localhost:6379",
-            Password: "secret",
-            DB:       0,
-        },
-        BlacklistPrefix: "token:blacklist:",  // Redis key prefix for blacklist
-    },
-}
-
-tm, err := tokens.New(config)
-```

--- a/tokens/issuer.go
+++ b/tokens/issuer.go
@@ -5,10 +5,12 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
+	"maps"
 	"net/url"
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	jwt "github.com/golang-jwt/jwt/v5"
@@ -16,9 +18,20 @@ import (
 	"github.com/oklog/ulid/v2"
 )
 
+// KeySet is the complete set of key material an issuer serves
+type KeySet struct {
+	// Signing holds the private keys eligible to sign, keyed by kid
+	Signing map[string]crypto.Signer
+	// Verification holds public keys that verify but never sign, keyed by kid
+	Verification map[string]crypto.PublicKey
+	// KID names the key in Signing to sign with; empty lets the issuer select one
+	KID string
+}
+
 // Issuer handles JWT token creation and signing. It manages signing keys and
 // provides methods to create access tokens, refresh tokens, and sign them
 type Issuer struct {
+	mu                   sync.RWMutex
 	conf                 Config
 	currentKeyID         string
 	currentKey           crypto.Signer
@@ -40,11 +53,12 @@ func NewIssuer(conf Config) (*Issuer, error) {
 	}
 
 	issuer := &Issuer{
-		conf:         conf,
-		keys:         make(map[string]crypto.PublicKey),
-		signingKeys:  make(map[string]crypto.Signer),
-		keyLifecycle: newKeyLifecycleManager(),
-		jwksCache:    newJWKSCache(conf.JWKSCacheTTL),
+		conf:            conf,
+		keys:            make(map[string]crypto.PublicKey),
+		signingKeys:     make(map[string]crypto.Signer),
+		keyLifecycle:    newKeyLifecycleManager(),
+		jwksCache:       newJWKSCache(conf.JWKSCacheTTL),
+		refreshAudience: resolveRefreshAudience(conf),
 		kidEntropy: &ulid.LockedMonotonicReader{
 			MonotonicReader: ulid.Monotonic(rand.Reader, 0),
 		},
@@ -83,7 +97,9 @@ func NewIssuer(conf Config) (*Issuer, error) {
 		loaded = append(loaded, info)
 	}
 
-	issuer.selectInitialKey(loaded, conf.KID)
+	issuer.mu.Lock()
+	issuer.selectInitialKeyLocked(loaded, conf.KID)
+	issuer.mu.Unlock()
 
 	if issuer.currentKey == nil {
 		return nil, ErrTokenManagerFailedInit
@@ -101,11 +117,12 @@ func NewIssuerWithKey(key crypto.Signer, conf Config) (*Issuer, error) {
 	}
 
 	issuer := &Issuer{
-		conf:         conf,
-		keys:         make(map[string]crypto.PublicKey),
-		signingKeys:  make(map[string]crypto.Signer),
-		keyLifecycle: newKeyLifecycleManager(),
-		jwksCache:    newJWKSCache(conf.JWKSCacheTTL),
+		conf:            conf,
+		keys:            make(map[string]crypto.PublicKey),
+		signingKeys:     make(map[string]crypto.Signer),
+		keyLifecycle:    newKeyLifecycleManager(),
+		jwksCache:       newJWKSCache(conf.JWKSCacheTTL),
+		refreshAudience: resolveRefreshAudience(conf),
 		kidEntropy: &ulid.LockedMonotonicReader{
 			MonotonicReader: ulid.Monotonic(rand.Reader, 0),
 		},
@@ -128,15 +145,27 @@ func NewIssuerWithKey(key crypto.Signer, conf Config) (*Issuer, error) {
 	return issuer, nil
 }
 
-// Sign an access or refresh token and return the signed token string.
+// Sign an access or refresh token and return the signed token string
 func (i *Issuer) Sign(token *jwt.Token) (string, error) {
-	if i.currentKey == nil || i.currentKeyID == "" {
+	i.mu.RLock()
+	key, kid := i.currentKey, i.currentKeyID
+	i.mu.RUnlock()
+
+	if key == nil || kid == "" {
 		return "", ErrTokenManagerFailedInit
 	}
 
-	token.Header["kid"] = i.currentKeyID
+	token.Header["kid"] = kid
 
-	return token.SignedString(i.currentKey)
+	return token.SignedString(key)
+}
+
+// signingMethod returns the signing method of the current signing key
+func (i *Issuer) signingMethod() jwt.SigningMethod {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+
+	return i.currentSigningMethod
 }
 
 // CreateAccessToken creates an access token from the provided claims.
@@ -165,7 +194,7 @@ func (i *Issuer) createAccessTokenWithDuration(claims *Claims, duration time.Dur
 		ExpiresAt: jwt.NewNumericDate(now.Add(duration)),
 	}
 
-	return jwt.NewWithClaims(i.currentSigningMethod, claims), nil
+	return jwt.NewWithClaims(i.signingMethod(), claims), nil
 }
 
 // CreateRefreshToken creates a refresh token from an access token.
@@ -191,7 +220,7 @@ func (i *Issuer) CreateRefreshToken(accessToken *jwt.Token) (*jwt.Token, error) 
 		OrgID: accessClaims.OrgID,
 	}
 
-	return jwt.NewWithClaims(i.currentSigningMethod, claims), nil
+	return jwt.NewWithClaims(i.signingMethod(), claims), nil
 }
 
 // CreateTokens creates and signs both access and refresh tokens in one step.
@@ -235,8 +264,13 @@ func (i *Issuer) Keys() (jwk.Set, error) {
 		return cached, nil
 	}
 
+	i.mu.RLock()
+	snapshot := maps.Clone(i.keys)
+	i.mu.RUnlock()
+
 	keys := jwk.NewSet()
-	for kid, pubkey := range i.keys {
+
+	for kid, pubkey := range snapshot {
 		key, err := jwk.Import(pubkey)
 		if err != nil {
 			return nil, err
@@ -268,25 +302,27 @@ func (i *Issuer) Keys() (jwk.Set, error) {
 
 // RefreshAudience returns the refresh audience for tokens
 func (i *Issuer) RefreshAudience() string {
-	if i.refreshAudience == "" {
-		if i.conf.RefreshAudience != "" {
-			i.refreshAudience = i.conf.RefreshAudience
-			return i.refreshAudience
-		}
+	return i.refreshAudience
+}
 
-		if aud, err := url.Parse(i.conf.Issuer); err == nil {
-			i.refreshAudience = aud.ResolveReference(&url.URL{Path: "/v1/refresh"}).String()
-		} else {
-			i.refreshAudience = DefaultRefreshAudience
-		}
+// resolveRefreshAudience derives the refresh audience from the configured audience or issuer
+// It is computed once during construction so reads never mutate the issuer
+func resolveRefreshAudience(conf Config) string {
+	if conf.RefreshAudience != "" {
+		return conf.RefreshAudience
 	}
 
-	return i.refreshAudience
+	aud, err := url.Parse(conf.Issuer)
+	if err != nil {
+		return DefaultRefreshAudience
+	}
+
+	return aud.ResolveReference(&url.URL{Path: "/v1/refresh"}).String()
 }
 
 // CurrentKey returns the ULID of the current signing key if it is ULID formatted
 func (i *Issuer) CurrentKey() ulid.ULID {
-	if id, err := ulid.Parse(i.currentKeyID); err == nil {
+	if id, err := ulid.Parse(i.CurrentKeyID()); err == nil {
 		return id
 	}
 
@@ -295,11 +331,115 @@ func (i *Issuer) CurrentKey() ulid.ULID {
 
 // CurrentKeyID returns the identifier of the current signing key
 func (i *Issuer) CurrentKeyID() string {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+
 	return i.currentKeyID
+}
+
+// SetKeySet atomically replaces the issuer's key material, letting callers retire a
+// signing key without invalidating tokens it already signed
+func (i *Issuer) SetKeySet(ks KeySet) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	keys := make(map[string]crypto.PublicKey, len(ks.Signing)+len(ks.Verification))
+	signingKeys := make(map[string]crypto.Signer, len(ks.Signing))
+
+	for kid, signer := range ks.Signing {
+		if kid == "" {
+			return ErrEmptySigningKeyID
+		}
+
+		keys[kid] = signer.Public()
+		signingKeys[kid] = signer
+	}
+
+	for kid, publicKey := range ks.Verification {
+		if kid == "" {
+			return ErrEmptySigningKeyID
+		}
+
+		// a kid that can sign is never downgraded to verification only
+		if _, ok := keys[kid]; !ok {
+			keys[kid] = publicKey
+		}
+	}
+
+	if len(signingKeys) == 0 {
+		return ErrTokenManagerFailedInit
+	}
+
+	if ks.KID != "" {
+		if _, ok := signingKeys[ks.KID]; !ok {
+			return ErrUnknownSigningKey
+		}
+	}
+
+	i.keys = keys
+	i.signingKeys = signingKeys
+
+	for kid, publicKey := range keys {
+		i.keyLifecycle.AddKey(kid, signingMethodForPublicKey(publicKey).Alg())
+	}
+
+	for _, kid := range i.keyLifecycle.List() {
+		if _, ok := keys[kid]; !ok {
+			i.keyLifecycle.RemoveKey(kid)
+		}
+	}
+
+	i.jwksCache.Invalidate()
+
+	i.currentKey = nil
+	i.currentKeyID = ""
+	i.currentSigningMethod = nil
+
+	i.selectInitialKeyLocked(loadedKeysFrom(signingKeys), ks.KID)
+
+	if i.currentKey == nil {
+		return ErrTokenManagerFailedInit
+	}
+
+	i.conf.KID = i.currentKeyID
+
+	return nil
+}
+
+// loadedKeysFrom builds the kid metadata selectInitialKeyLocked ranges over, in a stable order
+func loadedKeysFrom(signingKeys map[string]crypto.Signer) []loadedKey {
+	kids := make([]string, 0, len(signingKeys))
+	for kid := range signingKeys {
+		kids = append(kids, kid)
+	}
+
+	sort.Strings(kids)
+
+	loaded := make([]loadedKey, 0, len(kids))
+
+	for _, kid := range kids {
+		info := loadedKey{kid: kid}
+		if parsed, err := ulid.Parse(kid); err == nil {
+			info.ulid = parsed
+			info.hasULID = true
+		}
+
+		loaded = append(loaded, info)
+	}
+
+	return loaded
 }
 
 // AddKey registers a new signing key with the issuer
 func (i *Issuer) AddKey(kid string, signer crypto.Signer) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	return i.addKeyLocked(kid, signer)
+}
+
+// addKeyLocked registers a new signing key; callers must hold the write lock
+func (i *Issuer) addKeyLocked(kid string, signer crypto.Signer) error {
 	if kid == "" {
 		return ErrEmptySigningKeyID
 	}
@@ -349,6 +489,9 @@ func (i *Issuer) AddKey(kid string, signer crypto.Signer) error {
 
 // UseSigningKeyID sets the current signing key to the specified key ID.
 func (i *Issuer) UseSigningKeyID(kid string) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
 	key, ok := i.signingKeys[kid]
 	if !ok {
 		return ErrUnknownSigningKey
@@ -362,8 +505,11 @@ func (i *Issuer) UseSigningKeyID(kid string) error {
 	return nil
 }
 
-// RemoveSigningKeyByID removes a signing key from the issuer.
+// RemoveSigningKeyByID removes a signing key from the issuer
 func (i *Issuer) RemoveSigningKeyByID(kid string) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
 	delete(i.keys, kid)
 	delete(i.signingKeys, kid)
 
@@ -399,7 +545,7 @@ func (i *Issuer) RemoveSigningKeyByID(kid string) {
 
 		i.currentKey = nil
 		i.currentKeyID = ""
-		i.selectInitialKey(remaining, i.conf.KID)
+		i.selectInitialKeyLocked(remaining, i.conf.KID)
 
 		if i.currentKey != nil {
 			i.conf.KID = i.currentKeyID
@@ -407,12 +553,15 @@ func (i *Issuer) RemoveSigningKeyByID(kid string) {
 	}
 }
 
-// Config returns the issuer configuration.
+// Config returns the issuer configuration
 func (i *Issuer) Config() Config {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+
 	return i.conf
 }
 
-// keyFunc is the jwt.Keyfunc used for token verification.
+// keyFunc is the jwt.Keyfunc used for token verification
 func (i *Issuer) keyFunc(token *jwt.Token) (any, error) {
 	alg := token.Method.Alg()
 
@@ -430,7 +579,10 @@ func (i *Issuer) keyFunc(token *jwt.Token) (any, error) {
 		return nil, ErrFailedParsingKid
 	}
 
+	i.mu.RLock()
 	key, ok := i.keys[kidStr]
+	i.mu.RUnlock()
+
 	if !ok {
 		return nil, ErrUnknownSigningKey
 	}
@@ -438,8 +590,9 @@ func (i *Issuer) keyFunc(token *jwt.Token) (any, error) {
 	return key, nil
 }
 
-// selectInitialKey selects the initial signing key based on the desired key ID or the most recent ULID key
-func (i *Issuer) selectInitialKey(loaded []loadedKey, desired string) {
+// selectInitialKeyLocked selects the initial signing key based on the desired key ID or the
+// most recent ULID key; callers must hold the write lock
+func (i *Issuer) selectInitialKeyLocked(loaded []loadedKey, desired string) {
 	if desired != "" {
 		if signer, ok := i.signingKeys[desired]; ok {
 			i.currentKeyID = desired
@@ -492,7 +645,12 @@ func (i *Issuer) genKeyID() (ulid.ULID, error) {
 
 // signingMethodForKey detects the signing method from a crypto.Signer using jwx
 func signingMethodForKey(signer crypto.Signer) jwt.SigningMethod {
-	key, err := jwk.Import(signer.Public())
+	return signingMethodForPublicKey(signer.Public())
+}
+
+// signingMethodForPublicKey detects the signing method from a public key using jwx
+func signingMethodForPublicKey(publicKey crypto.PublicKey) jwt.SigningMethod {
+	key, err := jwk.Import(publicKey)
 	if err != nil {
 		return jwt.SigningMethodEdDSA
 	}

--- a/tokens/key_lifecycle.go
+++ b/tokens/key_lifecycle.go
@@ -4,6 +4,8 @@ import (
 	"crypto"
 	"crypto/ed25519"
 	"crypto/rand"
+	"maps"
+	"slices"
 	"sync"
 	"time"
 
@@ -109,6 +111,14 @@ func (klm *keyLifecycleManager) AddKey(kid string, algorithm string) {
 	}
 }
 
+// List returns every key ID the manager holds metadata for
+func (klm *keyLifecycleManager) List() []string {
+	klm.mu.RLock()
+	defer klm.mu.RUnlock()
+
+	return slices.Collect(maps.Keys(klm.metadata))
+}
+
 // GetMetadata returns metadata for a key
 func (klm *keyLifecycleManager) GetMetadata(kid string) (*KeyMetadata, bool) {
 	klm.mu.RLock()
@@ -209,7 +219,7 @@ func (tm *TokenManager) ShouldRotate(maxAge time.Duration) bool {
 		return false
 	}
 
-	meta, exists := tm.keyLifecycle.GetMetadata(tm.currentKeyID)
+	meta, exists := tm.keyLifecycle.GetMetadata(tm.CurrentKeyID())
 	if !exists {
 		return false
 	}
@@ -289,7 +299,7 @@ func (tm *TokenManager) RotateKeys(generateKey RotateKeyFunc, deprecationGrace t
 		RevokedKeys:    []string{},
 	}
 
-	previousKeyID := tm.currentKeyID
+	previousKeyID := tm.CurrentKeyID()
 
 	kid, signer, err := generateKey()
 	if err != nil {

--- a/tokens/keyset_test.go
+++ b/tokens/keyset_test.go
@@ -1,0 +1,217 @@
+package tokens_test
+
+import (
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
+	"sync"
+	"testing"
+	"time"
+
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+
+	"github.com/theopenlane/iam/tokens"
+)
+
+func keySetConfig() tokens.Config {
+	return tokens.Config{
+		Audience:        "http://localhost:3000",
+		Issuer:          "http://localhost:3001",
+		AccessDuration:  time.Hour,
+		RefreshDuration: 2 * time.Hour,
+		RefreshOverlap:  -15 * time.Minute,
+	}
+}
+
+func newSigner(t *testing.T) crypto.Signer {
+	t.Helper()
+
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	return priv
+}
+
+func keySetClaims() *tokens.Claims {
+	return &tokens.Claims{
+		RegisteredClaims: jwt.RegisteredClaims{Subject: "01H6PGFB4T34D4WWEXQMAGJNMK"},
+	}
+}
+
+func tokenKeyID(t *testing.T, tks string) string {
+	t.Helper()
+
+	token, _, err := jwt.NewParser().ParseUnverified(tks, &jwt.RegisteredClaims{})
+	require.NoError(t, err)
+
+	kid, ok := token.Header["kid"].(string)
+	require.True(t, ok)
+
+	return kid
+}
+
+func TestSetKeySetSelectsSigningKey(t *testing.T) {
+	t.Parallel()
+
+	tm, err := tokens.NewWithKey(newSigner(t), keySetConfig())
+	require.NoError(t, err)
+
+	first, second := newSigner(t), newSigner(t)
+
+	require.NoError(t, tm.SetKeySet(tokens.KeySet{
+		Signing: map[string]crypto.Signer{"first": first, "second": second},
+		KID:     "second",
+	}))
+
+	require.Equal(t, "second", tm.CurrentKeyID())
+
+	atks, _, err := tm.CreateTokenPair(keySetClaims())
+	require.NoError(t, err)
+	require.Equal(t, "second", tokenKeyID(t, atks))
+
+	// the key the manager was constructed with is gone once the set is replaced
+	jwks, err := tm.Keys()
+	require.NoError(t, err)
+	require.Equal(t, 2, jwks.Len())
+}
+
+func TestSetKeySetVerificationOnlyKeysStayValid(t *testing.T) {
+	t.Parallel()
+
+	retiring := newSigner(t)
+
+	tm, err := tokens.NewWithKey(retiring, keySetConfig())
+	require.NoError(t, err)
+
+	require.NoError(t, tm.SetKeySet(tokens.KeySet{
+		Signing: map[string]crypto.Signer{"retiring": retiring},
+		KID:     "retiring",
+	}))
+
+	old, _, err := tm.CreateTokenPair(keySetClaims())
+	require.NoError(t, err)
+
+	// the retiring key loses its signer but keeps verifying, as it would once its
+	// private material is replaced on disk
+	replacement := newSigner(t)
+
+	require.NoError(t, tm.SetKeySet(tokens.KeySet{
+		Signing:      map[string]crypto.Signer{"replacement": replacement},
+		Verification: map[string]crypto.PublicKey{"retiring": retiring.Public()},
+		KID:          "replacement",
+	}))
+
+	fresh, _, err := tm.CreateTokenPair(keySetClaims())
+	require.NoError(t, err)
+	require.Equal(t, "replacement", tokenKeyID(t, fresh))
+
+	claims, err := tm.Verify(old)
+	require.NoError(t, err)
+	require.Equal(t, "01H6PGFB4T34D4WWEXQMAGJNMK", claims.Subject)
+
+	_, err = tm.Verify(fresh)
+	require.NoError(t, err)
+
+	// both kids are published so external validators can still resolve the old one
+	jwks, err := tm.Keys()
+	require.NoError(t, err)
+	require.Equal(t, 2, jwks.Len())
+}
+
+func TestSetKeySetRejectsUnusableSets(t *testing.T) {
+	t.Parallel()
+
+	tm, err := tokens.NewWithKey(newSigner(t), keySetConfig())
+	require.NoError(t, err)
+
+	signer := newSigner(t)
+	before := tm.CurrentKeyID()
+
+	// a kid that cannot sign is never silently swapped for another key
+	err = tm.SetKeySet(tokens.KeySet{
+		Signing: map[string]crypto.Signer{"present": signer},
+		KID:     "absent",
+	})
+	require.ErrorIs(t, err, tokens.ErrUnknownSigningKey)
+
+	err = tm.SetKeySet(tokens.KeySet{
+		Verification: map[string]crypto.PublicKey{"verify-only": signer.Public()},
+	})
+	require.ErrorIs(t, err, tokens.ErrTokenManagerFailedInit)
+
+	err = tm.SetKeySet(tokens.KeySet{
+		Signing: map[string]crypto.Signer{"": signer},
+	})
+	require.ErrorIs(t, err, tokens.ErrEmptySigningKeyID)
+
+	// a rejected set leaves the issuer untouched
+	require.Equal(t, before, tm.CurrentKeyID())
+}
+
+func TestSetKeySetConcurrentWithTokenTraffic(t *testing.T) {
+	t.Parallel()
+
+	tm, err := tokens.NewWithKey(newSigner(t), keySetConfig())
+	require.NoError(t, err)
+
+	rotations := []tokens.KeySet{}
+
+	for _, kid := range []string{"alpha", "beta", "gamma"} {
+		signer := newSigner(t)
+		rotations = append(rotations, tokens.KeySet{
+			Signing: map[string]crypto.Signer{kid: signer},
+			KID:     kid,
+		})
+	}
+
+	require.NoError(t, tm.SetKeySet(rotations[0]))
+
+	var readers, rotator sync.WaitGroup
+
+	done := make(chan struct{})
+
+	// rotate the key set underneath live traffic; without the issuer lock this races
+	// with every reader below
+	rotator.Add(1)
+
+	go func() {
+		defer rotator.Done()
+
+		for i := 0; ; i++ {
+			select {
+			case <-done:
+				return
+			default:
+			}
+
+			require.NoError(t, tm.SetKeySet(rotations[i%len(rotations)]))
+		}
+	}()
+
+	for range 8 {
+		readers.Add(1)
+
+		go func() {
+			defer readers.Done()
+
+			for range 200 {
+				atks, _, err := tm.CreateTokenPair(keySetClaims())
+				require.NoError(t, err)
+
+				// the signing key may have rotated between signing and verifying, so a
+				// verification failure here is expected; the point is that neither call panics
+				_, _ = tm.Verify(atks)
+
+				_, err = tm.Keys()
+				require.NoError(t, err)
+
+				require.NotEmpty(t, tm.CurrentKeyID())
+			}
+		}()
+	}
+
+	readers.Wait()
+	close(done)
+	rotator.Wait()
+}

--- a/tokens/tokenmanager.go
+++ b/tokens/tokenmanager.go
@@ -217,13 +217,9 @@ func (tm *TokenManager) CreateImpersonationToken(_ context.Context, opts CreateI
 		OriginalToken:     opts.OriginalToken,
 	}
 
-	token := jwt.NewWithClaims(tm.currentSigningMethod, claims)
+	token := jwt.NewWithClaims(tm.signingMethod(), claims)
 
-	// Add key ID to header
-	if tm.conf.KID != "" {
-		token.Header["kid"] = tm.conf.KID
-	}
-
+	// Sign stamps the header with the current kid
 	return tm.Sign(token)
 }
 


### PR DESCRIPTION
Goal of the PR is to work in concert + conjunction with the `core` repo to allow for automated certificate renewal and reload, but transparent to active sessions and users.

- Signing keys can be swapped on a running service, so rotating one no longer means a restart or rebuilding everything holding a reference to the token manager
- Keys that stop signing can stay on for verification only, so retiring one doesn't invalidate the tokens it already handed out