### PR TITLE
feat: skip audit log for integration user

### DIFF
--- a/auth/caller.go
+++ b/auth/caller.go
@@ -16,7 +16,7 @@ const (
 	CapBypassFGA Capability = 1 << 2
 	// CapBypassManagedGroup bypasses managed-group mutation guards
 	CapBypassManagedGroup Capability = 1 << 3
-	// CapBypassAuditLog suppresses audit log emission
+	// CapBypassAuditLog suppresses audit log emission, skips writes to history tables
 	CapBypassAuditLog Capability = 1 << 4
 	// CapInternalOperation marks the caller as a trusted internal service operation
 	CapInternalOperation Capability = 1 << 5

--- a/auth/virtual.go
+++ b/auth/virtual.go
@@ -52,7 +52,8 @@ func NewIntegrationCaller(orgID string) *Caller {
 	}
 }
 
-// EnsureIntegrationCaller fills the integration actor identity on subject-less callers, retaining attributed ones
+// EnsureIntegrationCaller fills the integration actor identity on subject-less callers, retaining attributed ones, granting audit-log bypass either way so integration-driven
+// writes skip history tables
 func EnsureIntegrationCaller(ctx context.Context, orgID string) context.Context {
 	caller, ok := CallerFromContext(ctx)
 	if !ok || caller == nil {
@@ -60,14 +61,17 @@ func EnsureIntegrationCaller(ctx context.Context, orgID string) context.Context 
 	}
 
 	if caller.SubjectID != "" {
-		return EnsureCallerOrg(ctx, orgID)
+		attributed := *caller
+		attributed.Capabilities |= CapBypassAuditLog
+
+		return EnsureCallerOrg(WithCaller(ctx, &attributed), orgID)
 	}
 
 	attributed := *caller
 	attributed.SubjectID = IntegrationSubjectID
 	attributed.SubjectName = IntegrationDisplayName
 	attributed.SubjectEmail = IntegrationEmail
-	attributed.Capabilities |= CapIntegrationActor
+	attributed.Capabilities |= CapIntegrationActor | CapBypassAuditLog
 
 	return EnsureCallerOrg(WithCaller(ctx, &attributed), orgID)
 }

--- a/auth/virtual.go
+++ b/auth/virtual.go
@@ -48,7 +48,7 @@ func NewIntegrationCaller(orgID string) *Caller {
 		SubjectName:    IntegrationDisplayName,
 		SubjectEmail:   IntegrationEmail,
 		OrganizationID: orgID,
-		Capabilities:   CapIntegrationActor | CapBypassOrgFilter | CapBypassFGA | CapInternalOperation,
+		Capabilities:   CapIntegrationActor | CapBypassOrgFilter | CapBypassFGA | CapInternalOperation | CapBypassAuditLog,
 	}
 }
 

--- a/auth/virtual_test.go
+++ b/auth/virtual_test.go
@@ -110,13 +110,13 @@ func TestNewIntegrationCaller(t *testing.T) {
 		t.Errorf("OrganizationID: want org-1, got %s", c.OrganizationID)
 	}
 
-	for _, cap := range []Capability{CapIntegrationActor, CapBypassOrgFilter, CapBypassFGA, CapInternalOperation} {
+	for _, cap := range []Capability{CapIntegrationActor, CapBypassOrgFilter, CapBypassFGA, CapInternalOperation, CapBypassAuditLog} {
 		if !c.Has(cap) {
 			t.Errorf("NewIntegrationCaller must have cap %d", cap)
 		}
 	}
 
-	for _, cap := range []Capability{CapBypassFeatureCheck, CapBypassSubscriptionCheck, CapBypassAuditLog, CapSystemAdmin} {
+	for _, cap := range []Capability{CapBypassFeatureCheck, CapBypassSubscriptionCheck, CapSystemAdmin} {
 		if c.Has(cap) {
 			t.Errorf("NewIntegrationCaller must not have cap %d", cap)
 		}


### PR DESCRIPTION
Adding a history skipper to core that has
```
const skipper = `
    caller, _ := auth.CallerFromContext(ctx)
    return caller.HasInLineage(auth.CapBypassAuditLog)
`
```