### PR TITLE
Setup ConfigOpts, allow for claims data customization

### DIFF
--- a/tokens/claims.go
+++ b/tokens/claims.go
@@ -25,19 +25,14 @@ type Claims struct {
 	OrgID string `json:"org,omitempty"`
 	// Scopes lists objects that can be accessed for each permission level
 	Scopes PermissionScopes `json:"scopes,omitempty"`
-
 	// TrustCenterID is the internal generated mapping ID for the trust center the JWT token is valid for
 	TrustCenterID string `json:"trust_center_id,omitempty"`
-
 	// Modules is a list of modules that are enabled for the user in their current organization
 	Modules []string `json:"modules,omitempty"`
-
 	// Email is the email address of the user
 	Email string `json:"email,omitempty"`
-
 	// AssessmentID is the id of the questionnaire to fill
 	AssessmentID string `json:"assessment_id,omitempty"`
-
 	// AssessmentPreview marks the token as a sender preview (is_test) so the questionnaire
 	// resolves to the test response rather than a real recipient's response
 	AssessmentPreview bool `json:"assessment_preview,omitempty"`

--- a/tokens/config.go
+++ b/tokens/config.go
@@ -3,12 +3,21 @@ package tokens
 import (
 	"encoding/base64"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/theopenlane/utils/cache"
 )
 
 const (
+	// DefaultAccessDuration is the access token duration applied when none is configured
+	DefaultAccessDuration = time.Hour
+	// DefaultRefreshDuration is the refresh token duration applied when none is configured
+	DefaultRefreshDuration = 2 * time.Hour
+	// DefaultRefreshOverlap is the refresh overlap applied when none is configured
+	DefaultRefreshOverlap = -15 * time.Minute
+	// DefaultJWKSCacheTTL is the JWKS cache duration applied when none is configured
+	DefaultJWKSCacheTTL = 5 * time.Minute
 	// MinAccessDuration is the minimum allowed access token duration
 	MinAccessDuration = 5 * time.Minute
 	// MaxAccessDuration is the maximum allowed access token duration
@@ -63,6 +72,90 @@ type Config struct {
 	AssessmentAccessDuration time.Duration `json:"assessmentaccessduration" koanf:"assessmentaccessduration" default:"1h"`
 	// TrustCenterNDARequestAccessDuration represents the validity duration of the access token used for trust center NDA requests
 	TrustCenterNDARequestAccessDuration time.Duration `json:"trustcenterndarequestaccessduration" koanf:"trustcenterndarequestaccessduration" default:"1h"`
+	// Subject is the subject bound into minted tokens, set per operation
+	Subject string `json:"-" koanf:"-"`
+	// ExtraClaims holds additional claims minted into tokens, set per operation
+	ExtraClaims map[string]any `json:"-" koanf:"-"`
+	// RequiredAlgorithm refuses signing when the current key uses a different algorithm
+	RequiredAlgorithm string `json:"-" koanf:"-"`
+}
+
+// ConfigOpt customizes a Config at construction or derives a per-operation copy
+type ConfigOpt func(*Config)
+
+// NewConfig returns a Config with defaults and the supplied options applied
+func NewConfig(opts ...ConfigOpt) Config {
+	conf := Config{
+		AccessDuration:  DefaultAccessDuration,
+		RefreshDuration: DefaultRefreshDuration,
+		RefreshOverlap:  DefaultRefreshOverlap,
+		JWKSCacheTTL:    DefaultJWKSCacheTTL,
+		GenerateKeys:    true,
+	}
+
+	for _, opt := range opts {
+		opt(&conf)
+	}
+
+	return conf
+}
+
+// WithIssuer sets the issuer for minting and verification
+func WithIssuer(issuer string) ConfigOpt {
+	return func(c *Config) {
+		c.Issuer = issuer
+	}
+}
+
+// WithAudience sets the audience for minting and verification
+func WithAudience(audience string) ConfigOpt {
+	return func(c *Config) {
+		c.Audience = audience
+	}
+}
+
+// WithSubject sets the subject bound into minted tokens
+func WithSubject(subject string) ConfigOpt {
+	return func(c *Config) {
+		c.Subject = subject
+	}
+}
+
+// WithAccessDuration overrides the configured access token duration
+func WithAccessDuration(duration time.Duration) ConfigOpt {
+	return func(c *Config) {
+		c.AccessDuration = duration
+	}
+}
+
+// WithClaim adds one extra claim; registered claims always win
+func WithClaim(name string, value any) ConfigOpt {
+	return func(c *Config) {
+		if c.ExtraClaims == nil {
+			c.ExtraClaims = map[string]any{}
+		}
+
+		c.ExtraClaims[name] = value
+	}
+}
+
+// WithRequiredAlgorithm refuses to sign when the current key uses a different algorithm
+func WithRequiredAlgorithm(alg string) ConfigOpt {
+	return func(c *Config) {
+		c.RequiredAlgorithm = alg
+	}
+}
+
+// derive returns a copy with the options applied, cloning ExtraClaims so the base is never mutated
+func (c Config) derive(opts ...ConfigOpt) Config {
+	conf := c
+	conf.ExtraClaims = maps.Clone(conf.ExtraClaims)
+
+	for _, opt := range opts {
+		opt(&conf)
+	}
+
+	return conf
 }
 
 // RedisConfig contains Redis configuration for token security features

--- a/tokens/errors.go
+++ b/tokens/errors.go
@@ -69,6 +69,8 @@ var (
 	ErrAudienceRequired = errors.New("audience is required")
 	// ErrIssuerRequired is returned when issuer is not specified
 	ErrIssuerRequired = errors.New("issuer is required")
+	// ErrSigningAlgorithmMismatch is returned when the current signing key does not use the algorithm the operation requires
+	ErrSigningAlgorithmMismatch = errors.New("current signing key does not use the required algorithm")
 	// ErrAPITokenMultipleActive is returned when multiple keys are marked as active
 	ErrAPITokenMultipleActive = errors.New("only one api token key can be active at a time")
 	// ErrAPITokenNoActive is returned when API tokens are enabled but no active key exists

--- a/tokens/issuer.go
+++ b/tokens/issuer.go
@@ -168,13 +168,10 @@ func (i *Issuer) signingMethod() jwt.SigningMethod {
 	return i.currentSigningMethod
 }
 
-// CreateAccessToken creates an access token from the provided claims.
-func (i *Issuer) CreateAccessToken(claims *Claims) (*jwt.Token, error) {
-	return i.createAccessTokenWithDuration(claims, i.conf.AccessDuration)
-}
+// CreateAccessToken creates an access token from the provided claims and config options
+func (i *Issuer) CreateAccessToken(claims *Claims, opts ...ConfigOpt) (*jwt.Token, error) {
+	conf := i.Config().derive(opts...)
 
-// createAccessTokenWithDuration creates an access token with a specified duration.
-func (i *Issuer) createAccessTokenWithDuration(claims *Claims, duration time.Duration) (*jwt.Token, error) {
 	now := time.Now()
 	sub := claims.Subject
 
@@ -187,14 +184,48 @@ func (i *Issuer) createAccessTokenWithDuration(claims *Claims, duration time.Dur
 	claims.RegisteredClaims = jwt.RegisteredClaims{
 		ID:        strings.ToLower(kid.String()),
 		Subject:   sub,
-		Audience:  jwt.ClaimStrings{i.conf.Audience},
-		Issuer:    i.conf.Issuer,
+		Audience:  jwt.ClaimStrings{conf.Audience},
+		Issuer:    conf.Issuer,
 		IssuedAt:  issueTime,
 		NotBefore: issueTime,
-		ExpiresAt: jwt.NewNumericDate(now.Add(duration)),
+		ExpiresAt: jwt.NewNumericDate(now.Add(conf.AccessDuration)),
 	}
 
 	return jwt.NewWithClaims(i.signingMethod(), claims), nil
+}
+
+// CreateSignedToken mints and signs a token from the derived config; the iat, nbf,
+// and jti claims are always server-derived
+func (i *Issuer) CreateSignedToken(opts ...ConfigOpt) (string, error) {
+	conf := i.Config().derive(opts...)
+
+	method := i.signingMethod()
+	if conf.RequiredAlgorithm != "" && method.Alg() != conf.RequiredAlgorithm {
+		return "", ErrSigningAlgorithmMismatch
+	}
+
+	jti, err := i.genKeyID()
+	if err != nil {
+		return "", err
+	}
+
+	now := time.Now()
+
+	claims := jwt.MapClaims{}
+	maps.Copy(claims, conf.ExtraClaims)
+
+	claims["iss"] = conf.Issuer
+	claims["aud"] = conf.Audience
+	claims["iat"] = jwt.NewNumericDate(now)
+	claims["nbf"] = jwt.NewNumericDate(now)
+	claims["exp"] = jwt.NewNumericDate(now.Add(conf.AccessDuration))
+	claims["jti"] = strings.ToLower(jti.String())
+
+	if conf.Subject != "" {
+		claims["sub"] = conf.Subject
+	}
+
+	return i.Sign(jwt.NewWithClaims(method, claims))
 }
 
 // CreateRefreshToken creates a refresh token from an access token.
@@ -221,29 +252,6 @@ func (i *Issuer) CreateRefreshToken(accessToken *jwt.Token) (*jwt.Token, error) 
 	}
 
 	return jwt.NewWithClaims(i.signingMethod(), claims), nil
-}
-
-// CreateTokens creates and signs both access and refresh tokens in one step.
-func (i *Issuer) CreateTokens(claims *Claims) (accessToken, refreshToken string, err error) {
-	var atk, rtk *jwt.Token
-
-	if atk, err = i.CreateAccessToken(claims); err != nil {
-		return "", "", fmt.Errorf("could not create access token: %w", err)
-	}
-
-	if rtk, err = i.CreateRefreshToken(atk); err != nil {
-		return "", "", fmt.Errorf("could not create refresh token: %w", err)
-	}
-
-	if accessToken, err = i.Sign(atk); err != nil {
-		return "", "", fmt.Errorf("could not sign access token: %w", err)
-	}
-
-	if refreshToken, err = i.Sign(rtk); err != nil {
-		return "", "", fmt.Errorf("could not sign refresh token: %w", err)
-	}
-
-	return accessToken, refreshToken, nil
 }
 
 // Parse parses a token without validating claims (but does verify signature).

--- a/tokens/jwks.go
+++ b/tokens/jwks.go
@@ -24,8 +24,7 @@ type JWKSValidator struct {
 func NewJWKSValidator(keys jwk.Set, audience, issuer string) *JWKSValidator {
 	validator := &JWKSValidator{
 		validator: validator{
-			audience: audience,
-			issuer:   issuer,
+			conf: NewConfig(WithAudience(audience), WithIssuer(issuer)),
 		},
 		keys: keys,
 	}

--- a/tokens/signed_token_test.go
+++ b/tokens/signed_token_test.go
@@ -1,0 +1,167 @@
+package tokens_test
+
+import (
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/theopenlane/iam/tokens"
+)
+
+const (
+	// mintIssuer is the issuer bound into minted tokens
+	mintIssuer = "https://auth.example.com"
+	// mintAudience is the platform audience configured on the manager
+	mintAudience = "https://api.example.com"
+	// mintFederationAudience is a per-operation audience override for federation exchanges
+	mintFederationAudience = "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider"
+	// mintSubject is the subject bound into minted tokens
+	mintSubject = "01JQZX9K8N7M6P5R4T3V2W1Y0Z"
+	// mintRSAKeySize is the smallest RSA key size the signing key loader accepts
+	mintRSAKeySize = 2048
+)
+
+// signedTokenManager builds a token manager signing with the supplied key
+func signedTokenManager(t *testing.T, key crypto.Signer) *tokens.TokenManager {
+	t.Helper()
+
+	manager, err := tokens.NewWithKey(key, tokens.NewConfig(
+		tokens.WithIssuer(mintIssuer),
+		tokens.WithAudience(mintAudience),
+	))
+	require.NoError(t, err)
+
+	return manager
+}
+
+// parseSignedToken verifies the token signature and returns its claims and parsed token
+func parseSignedToken(t *testing.T, signed string, key crypto.Signer) (jwt.MapClaims, *jwt.Token) {
+	t.Helper()
+
+	claims := jwt.MapClaims{}
+
+	token, err := jwt.ParseWithClaims(signed, claims, func(*jwt.Token) (any, error) {
+		return key.Public(), nil
+	})
+	require.NoError(t, err)
+	require.True(t, token.Valid)
+
+	return claims, token
+}
+
+// TestNewConfig verifies default stamping and option layering
+func TestNewConfig(t *testing.T) {
+	conf := tokens.NewConfig(
+		tokens.WithIssuer(mintIssuer),
+		tokens.WithAudience(mintAudience),
+	)
+
+	assert.Equal(t, mintIssuer, conf.Issuer)
+	assert.Equal(t, mintAudience, conf.Audience)
+	assert.Equal(t, tokens.DefaultAccessDuration, conf.AccessDuration)
+	assert.Equal(t, tokens.DefaultRefreshDuration, conf.RefreshDuration)
+	assert.Equal(t, tokens.DefaultRefreshOverlap, conf.RefreshOverlap)
+	assert.Equal(t, tokens.DefaultJWKSCacheTTL, conf.JWKSCacheTTL)
+	assert.True(t, conf.GenerateKeys)
+
+	require.NoError(t, conf.Validate())
+}
+
+// TestCreateSignedToken verifies config-derived minting on the token manager
+func TestCreateSignedToken(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, mintRSAKeySize)
+	require.NoError(t, err)
+
+	manager := signedTokenManager(t, key)
+
+	t.Run("mints a verifiable token from the derived config", func(t *testing.T) {
+		signed, err := manager.CreateSignedToken(
+			tokens.WithSubject(mintSubject),
+			tokens.WithAudience(mintFederationAudience),
+			tokens.WithAccessDuration(10*time.Minute),
+			tokens.WithClaim("organization_id", mintSubject),
+			tokens.WithRequiredAlgorithm(jwt.SigningMethodRS256.Alg()),
+		)
+		require.NoError(t, err)
+
+		claims, token := parseSignedToken(t, signed, key)
+
+		assert.Equal(t, jwt.SigningMethodRS256.Alg(), token.Method.Alg())
+		assert.Equal(t, manager.CurrentKeyID(), token.Header["kid"])
+
+		assert.Equal(t, mintIssuer, claims["iss"])
+		assert.Equal(t, mintFederationAudience, claims["aud"])
+		assert.Equal(t, mintSubject, claims["sub"])
+		assert.Equal(t, mintSubject, claims["organization_id"])
+		assert.NotEmpty(t, claims["jti"])
+
+		expiry, err := claims.GetExpirationTime()
+		require.NoError(t, err)
+		assert.WithinDuration(t, time.Now().Add(10*time.Minute), expiry.Time, time.Minute)
+
+		issued, err := claims.GetIssuedAt()
+		require.NoError(t, err)
+		assert.False(t, issued.IsZero())
+
+		notBefore, err := claims.GetNotBefore()
+		require.NoError(t, err)
+		assert.False(t, notBefore.IsZero())
+	})
+
+	t.Run("defaults to the configured audience and access duration", func(t *testing.T) {
+		signed, err := manager.CreateSignedToken()
+		require.NoError(t, err)
+
+		claims, _ := parseSignedToken(t, signed, key)
+
+		assert.Equal(t, mintAudience, claims["aud"])
+		assert.NotContains(t, claims, "sub")
+
+		expiry, err := claims.GetExpirationTime()
+		require.NoError(t, err)
+		assert.WithinDuration(t, time.Now().Add(tokens.DefaultAccessDuration), expiry.Time, time.Minute)
+	})
+
+	t.Run("registered claims always win over extra claims", func(t *testing.T) {
+		signed, err := manager.CreateSignedToken(
+			tokens.WithSubject(mintSubject),
+			tokens.WithClaim("iss", "https://evil.example.com"),
+			tokens.WithClaim("sub", "01EVIL0000000000000000000"),
+			tokens.WithClaim("exp", 0),
+		)
+		require.NoError(t, err)
+
+		claims, _ := parseSignedToken(t, signed, key)
+
+		assert.Equal(t, mintIssuer, claims["iss"])
+		assert.Equal(t, mintSubject, claims["sub"])
+	})
+
+	t.Run("per-operation claims never leak into later mints", func(t *testing.T) {
+		_, err := manager.CreateSignedToken(tokens.WithClaim("organization_id", mintSubject))
+		require.NoError(t, err)
+
+		signed, err := manager.CreateSignedToken()
+		require.NoError(t, err)
+
+		claims, _ := parseSignedToken(t, signed, key)
+		assert.NotContains(t, claims, "organization_id")
+	})
+
+	t.Run("refuses to sign when the required algorithm does not match", func(t *testing.T) {
+		_, edKey, keyErr := ed25519.GenerateKey(rand.Reader)
+		require.NoError(t, keyErr)
+
+		_, err := signedTokenManager(t, edKey).CreateSignedToken(
+			tokens.WithRequiredAlgorithm(jwt.SigningMethodRS256.Alg()),
+		)
+		require.ErrorIs(t, err, tokens.ErrSigningAlgorithmMismatch)
+	})
+}

--- a/tokens/tokenmanager.go
+++ b/tokens/tokenmanager.go
@@ -59,9 +59,8 @@ func New(conf Config) (tm *TokenManager, err error) {
 	tm = &TokenManager{
 		Issuer: issuer,
 		validator: validator{
-			audience: conf.Audience,
-			issuer:   conf.Issuer,
-			keyFunc:  issuer.keyFunc,
+			conf:    conf,
+			keyFunc: issuer.keyFunc,
 		},
 	}
 
@@ -135,9 +134,8 @@ func NewWithKey(key crypto.Signer, conf Config) (tm *TokenManager, err error) {
 	tm = &TokenManager{
 		Issuer: issuer,
 		validator: validator{
-			audience: conf.Audience,
-			issuer:   conf.Issuer,
-			keyFunc:  issuer.keyFunc,
+			conf:    conf,
+			keyFunc: issuer.keyFunc,
 		},
 	}
 
@@ -201,9 +199,9 @@ func (tm *TokenManager) CreateImpersonationToken(_ context.Context, opts CreateI
 			IssuedAt:  jwt.NewNumericDate(now),
 			ExpiresAt: jwt.NewNumericDate(now.Add(opts.Duration)),
 			NotBefore: jwt.NewNumericDate(now),
-			Issuer:    tm.conf.Issuer,
+			Issuer:    tm.Issuer.conf.Issuer,
 			Subject:   opts.TargetUserID,
-			Audience:  jwt.ClaimStrings{tm.conf.Audience},
+			Audience:  jwt.ClaimStrings{tm.Issuer.conf.Audience},
 			ID:        sessionID,
 		},
 		UserID:            opts.TargetUserID,
@@ -232,8 +230,8 @@ func (tm *TokenManager) ValidateImpersonationToken(ctx context.Context, tokenStr
 	// Parse with validation
 	parser := jwt.NewParser(
 		jwt.WithValidMethods(allowedAlgorithms),
-		jwt.WithAudience(tm.conf.Audience),
-		jwt.WithIssuer(tm.conf.Issuer),
+		jwt.WithAudience(tm.Issuer.conf.Audience),
+		jwt.WithIssuer(tm.Issuer.conf.Issuer),
 	)
 
 	token, err := parser.ParseWithClaims(tokenString, claims, tm.Issuer.keyFunc)
@@ -388,33 +386,11 @@ func (tm *TokenManager) SuspendUserWithDuration(ctx context.Context, userID stri
 	return tm.SuspendUser(ctx, userID, duration)
 }
 
-// CreateTokenPairOption allows you configure token pair generations
-type CreateTokenPairOption func(*createTokenPairConfig)
-
-type createTokenPairConfig struct {
-	duration time.Duration
-}
-
-// WithAccessDuration sets a custom access token duration, it overrides the default value set in the config
-func WithAccessDuration(d time.Duration) CreateTokenPairOption {
-	return func(c *createTokenPairConfig) {
-		c.duration = d
-	}
-}
-
 // CreateTokenPair returns signed access and refresh tokens for the specified claims in one step since usually you want both access and refresh tokens at the same time
-func (tm *TokenManager) CreateTokenPair(claims *Claims, opts ...CreateTokenPairOption) (accessToken, refreshToken string, err error) {
+func (tm *TokenManager) CreateTokenPair(claims *Claims, opts ...ConfigOpt) (accessToken, refreshToken string, err error) {
 	var atk, rtk *jwt.Token
 
-	cfg := &createTokenPairConfig{
-		duration: tm.conf.AccessDuration,
-	}
-
-	for _, opt := range opts {
-		opt(cfg)
-	}
-
-	if atk, err = tm.createAccessTokenWithDuration(claims, cfg.duration); err != nil {
+	if atk, err = tm.CreateAccessToken(claims, opts...); err != nil {
 		return "", "", fmt.Errorf("could not create access token: %w", err)
 	}
 

--- a/tokens/validator.go
+++ b/tokens/validator.go
@@ -22,8 +22,7 @@ type Validator interface {
 // validator implements the Validator interface, allowing structs in this package to
 // embed the validation code base and supply their own keyFunc; unifying functionality
 type validator struct {
-	audience  string
-	issuer    string
+	conf      Config
 	keyFunc   jwt.Keyfunc
 	blacklist TokenBlacklist
 }
@@ -46,11 +45,11 @@ func (v *validator) VerifyWithContext(ctx context.Context, tks string) (claims *
 		return nil, ErrTokenInvalidClaims
 	}
 
-	if !claims.VerifyAudience(v.audience, true) {
+	if !claims.VerifyAudience(v.conf.Audience, true) {
 		return nil, ErrTokenInvalidAudience
 	}
 
-	if !claims.VerifyIssuer(v.issuer, true) {
+	if !claims.VerifyIssuer(v.conf.Issuer, true) {
 		return nil, ErrTokenInvalidIssuer
 	}
 


### PR DESCRIPTION
- Minor refactors to allow for TokenManager config construction letting callers customize issuer, audience, subject, lifetime, and extra claims per operation instead of only at startup
- Updated so issuer can mint arbitrary signed tokens (e.g. OIDC federation assertions for workload identity)
- Token verification now shares the same configuration as signing