### PR TITLE
pull in new logx package, update logging

### DIFF
--- a/fgax/checks.go
+++ b/fgax/checks.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	ofgaclient "github.com/openfga/go-sdk/client"
-	"github.com/rs/zerolog/log"
+	"github.com/theopenlane/logx"
 	"github.com/theopenlane/utils/ulids"
 
 	"github.com/theopenlane/iam/auth"
@@ -69,7 +69,7 @@ func (c *Client) BatchCheckObjectAccess(ctx context.Context, checks []AccessChec
 	checkRequests := []ofgaclient.ClientBatchCheckItem{}
 
 	for _, ac := range checks {
-		check, err := toBatchCheckItem(ac)
+		check, err := toBatchCheckItem(ctx, ac)
 		if err != nil {
 			return nil, err
 		}
@@ -107,7 +107,7 @@ func (c *Client) BatchCheckObjectAccess(ctx context.Context, checks []AccessChec
 		if result.HasError() {
 			err := result.GetError()
 
-			log.Error().Str("error", err.GetMessage()).Interface("accessCheck", id).Str("type", getCheckErrorType(err)).Msg("error checking access")
+			logx.FromContext(ctx).Error().Str("error", err.GetMessage()).Interface("accessCheck", id).Str("type", getCheckErrorType(err)).Msg("error checking access")
 
 			continue
 		}
@@ -115,14 +115,14 @@ func (c *Client) BatchCheckObjectAccess(ctx context.Context, checks []AccessChec
 		// get id from the correlation ID
 		check, ok := getCheckItemByCorrelationID(id, checkRequests)
 		if !ok {
-			log.Error().Str("correlationID", id).Msg("correlation ID not found in checks")
+			logx.FromContext(ctx).Error().Str("correlationID", id).Msg("correlation ID not found in checks")
 
 			continue
 		}
 
 		obj, err := ParseEntity(check.Object)
 		if err != nil {
-			log.Error().Err(err).Str("object", check.Object).Msg("error parsing object")
+			logx.FromContext(ctx).Error().Err(err).Str("object", check.Object).Msg("error parsing object")
 
 			return nil, err
 		}
@@ -158,9 +158,9 @@ func (c *Client) CheckAccessHighConsistency(ctx context.Context, ac AccessCheck,
 	return c.checkTuple(ctx, *checkReq, opts...)
 }
 
-func toBatchCheckItem(ac AccessCheck) (*ofgaclient.ClientBatchCheckItem, error) {
+func toBatchCheckItem(ctx context.Context, ac AccessCheck) (*ofgaclient.ClientBatchCheckItem, error) {
 	if err := validateAccessCheck(ac); err != nil {
-		log.Error().Err(err).Interface("accessCheck", ac).Msg("invalid access check")
+		logx.FromContext(ctx).Error().Err(err).Interface("accessCheck", ac).Msg("invalid access check")
 
 		return nil, err
 	}
@@ -243,7 +243,7 @@ func (c *Client) ListRelations(ctx context.Context, ac ListAccess, opts ...Reque
 
 		relations, err = c.getRelationsFromModel(ctx, ac.ObjectType.String())
 		if err != nil {
-			log.Error().Err(err).Msg("error getting relations from model")
+			logx.FromContext(ctx).Error().Err(err).Msg("error getting relations from model")
 
 			return nil, err
 		}
@@ -311,7 +311,7 @@ func (c *Client) checkTuple(ctx context.Context, check ofgaclient.ClientCheckReq
 	data, err := c.Ofga.Check(ctx).Body(check).
 		Options(options).Execute()
 	if err != nil {
-		log.Error().Err(err).Interface("tuple", check).Msg("error checking tuple")
+		logx.FromContext(ctx).Error().Err(err).Interface("tuple", check).Msg("error checking tuple")
 
 		return false, err
 	}
@@ -417,7 +417,7 @@ func (c *Client) batchCheckTuples(ctx context.Context, checks []ofgaclient.Clien
 			// get id from the correlation ID
 			check, ok := getCheckItemByCorrelationID(i, checks)
 			if !ok {
-				log.Error().Str("correlationID", i).Msg("correlation ID not found in checks")
+				logx.FromContext(ctx).Error().Str("correlationID", i).Msg("correlation ID not found in checks")
 
 				continue
 			}

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,8 @@ require (
 	github.com/testcontainers/testcontainers-go v0.44.0
 	github.com/testcontainers/testcontainers-go/modules/openfga v0.44.0
 	github.com/theopenlane/echox v0.3.0
-	github.com/theopenlane/entx v0.33.0
+	github.com/theopenlane/entx v0.33.3
+	github.com/theopenlane/logx v0.1.0
 	github.com/theopenlane/utils v0.7.1
 	github.com/urfave/cli/v3 v3.11.0
 	github.com/vmihailenco/msgpack/v5 v5.4.1
@@ -78,6 +79,7 @@ require (
 	github.com/ebitengine/purego v0.10.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
+	github.com/fatih/color v1.19.0 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.2 // indirect
@@ -103,13 +105,14 @@ require (
 	github.com/hashicorp/hcl/v2 v2.24.0 // indirect
 	github.com/klauspost/compress v1.19.1 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/labstack/gommon v0.5.0 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.4 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect
 	github.com/lestrrat-go/option/v2 v2.0.0 // indirect
 	github.com/lib/pq v1.12.3 // indirect
 	github.com/lufia/plan9stats v0.0.0-20260330125221-c963978e514e // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
-	github.com/mattn/go-colorable v0.1.14 // indirect
+	github.com/mattn/go-colorable v0.1.15 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/mattn/go-sqlite3 v1.14.32 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,8 @@ github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/envoyproxy/protoc-gen-validate v1.3.3 h1:MVQghNeW+LZcmXe7SY1V36Z+WFMDjpqGAGacLe2T0ds=
 github.com/envoyproxy/protoc-gen-validate v1.3.3/go.mod h1:TsndJ/ngyIdQRhMcVVGDDHINPLWB7C82oDArY51KfB0=
+github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
+github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
 github.com/felixge/httpsnoop v1.1.0 h1:3YtUj32ZZkqZtt3sZZsClsymw/QDuVfpNhoA31zeORc=
 github.com/felixge/httpsnoop v1.1.0/go.mod h1:Zqxgdd+1Rkcz8euOqdr7lqgCRJztwr5hp9vDSi5UZCE=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -197,6 +199,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/labstack/echo/v5 v5.3.1 h1:75maCxkQVGualckLc/5s/ihgpH1a1Dc6AuGWNVNs6bw=
 github.com/labstack/echo/v5 v5.3.1/go.mod h1:4iEGNQiPPZnkfYpNR/L6fINd3NLiGWUD5+eBotFALas=
+github.com/labstack/gommon v0.5.0 h1:6VSQ2NOzsnEJ5W6+84E0RbcaDDmgB6NIAzWCczTEe6c=
+github.com/labstack/gommon v0.5.0/go.mod h1:Rzlg7HHy1maLfzBYGg9NZcVuz1sA68HHhLjhcEllYE0=
 github.com/lestrrat-go/blackmagic v1.0.4 h1:IwQibdnf8l2KoO+qC3uT4OaTWsW7tuRQXy9TRN9QanA=
 github.com/lestrrat-go/blackmagic v1.0.4/go.mod h1:6AWFyKNNj0zEXQYfTMPfZrAXUWUfTIZ5ECEUEJaijtw=
 github.com/lestrrat-go/dsig v1.3.0 h1:phjMOCXvYzhuIgn7Voe2rex8z166vGfxRxmqM25P9/Q=
@@ -217,8 +221,8 @@ github.com/lufia/plan9stats v0.0.0-20260330125221-c963978e514e h1:Q6MvJtQK/iRcRt
 github.com/lufia/plan9stats v0.0.0-20260330125221-c963978e514e/go.mod h1:autxFIvghDt3jPTLoqZ9OZ7s9qTGNAWmYCjVFWPX/zg=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
-github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
+github.com/mattn/go-colorable v0.1.15 h1:+u9SLTRGnXv73cEsnsmoZBom+dMU88B2M0aDcWy0/jY=
+github.com/mattn/go-colorable v0.1.15/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.24 h1:tGZZoVgT/KiqK1c8ocVLeDS8BSWMRd47J3Lbz7vsReI=
 github.com/mattn/go-isatty v0.0.24/go.mod h1:nMCL3Zebbrt45jsMDgnfIwz6ydEQApk5oEI3HqDio6A=
 github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuErjs=
@@ -334,8 +338,10 @@ github.com/testcontainers/testcontainers-go/modules/openfga v0.44.0 h1:ql9bhSEO9
 github.com/testcontainers/testcontainers-go/modules/openfga v0.44.0/go.mod h1:mYazHZ/v9091lsGp2eDj6al/cvQ5LPYQHFn127CReQA=
 github.com/theopenlane/echox v0.3.0 h1:uwOKEw+r1utGQoOR6dZQqAVuY5j8TcasqnTwO5+rMsA=
 github.com/theopenlane/echox v0.3.0/go.mod h1:yTrXnj7s3VNIg0FCvB7Dut2Elr+LqJKU/nruxx1E1cM=
-github.com/theopenlane/entx v0.33.0 h1:3ojP4RF4T44ndlR/LKzU6ueq+GVZi0rwZIwQbIhjFHc=
-github.com/theopenlane/entx v0.33.0/go.mod h1:CQc8om4cosC0QGB6W6QgRLKRPaf/b3Wlv932vWuGFto=
+github.com/theopenlane/entx v0.33.3 h1:HK1WvOoD+cifktDvaKjh1EOTzrpHAmAdz9YSMsZ+hV0=
+github.com/theopenlane/entx v0.33.3/go.mod h1:ubJf45e2Ivax9rq6tDUog6/Rthe3MT9pWB1EHnp9ylA=
+github.com/theopenlane/logx v0.1.0 h1:DjjGAElteKebYOW68Ee5CVGqQmkaZDvCPmhtf6BweOM=
+github.com/theopenlane/logx v0.1.0/go.mod h1:HgQNNZ2iUGdampF15KRfKabbWIaGBLGIrsg1vkijvP8=
 github.com/theopenlane/utils v0.7.1 h1:x+9kVMgOALYqAH6GaLaDb9tj16nzasoGM8X0v0XNTn8=
 github.com/theopenlane/utils v0.7.1/go.mod h1:uxiLqjtcqgH57yOpYl3tTfKuenGYyAROxHFMpXx6mDY=
 github.com/tinylib/msgp v1.6.4 h1:mOwYbyYDLPj35mkA2BjjYejgJk9BuHxDdvRnb6v2ZcQ=

--- a/sessions/middleware.go
+++ b/sessions/middleware.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	"github.com/redis/go-redis/v9"
-	"github.com/rs/zerolog/log"
 	echo "github.com/theopenlane/echox"
 	"github.com/theopenlane/echox/middleware"
+	"github.com/theopenlane/logx"
 	"github.com/theopenlane/utils/rout"
 )
 
@@ -133,7 +133,7 @@ func (sc *SessionConfig) DestroySession(ctx context.Context, w http.ResponseWrit
 	if err != nil {
 		// a missing cookie is normal; a cookie that is present but undecodable is anomalous and logged
 		if !errors.Is(err, http.ErrNoCookie) {
-			log.Warn().Err(err).Msg("could not decode session cookie on destroy; clearing it")
+			logx.FromContext(ctx).Warn().Err(err).Msg("could not decode session cookie on destroy; clearing it")
 		}
 
 		// no resolvable session to remove server-side, but still expire whatever cookie was presented
@@ -211,7 +211,12 @@ func (sc *SessionConfig) requestSession(r *http.Request) (*Session[map[string]an
 	// get session from request cookies
 	session, err := sc.SessionManager.Get(r, sc.CookieConfig.Name)
 	if err != nil {
-		log.Error().Err(err).Msg("unable to get session")
+		switch {
+		case errors.Is(err, http.ErrNoCookie):
+			logx.FromContext(r.Context()).Debug().Err(err).Msg("no session cookie on request")
+		default:
+			logx.FromContext(r.Context()).Error().Err(err).Msg("unable to get session")
+		}
 
 		return nil, "", ErrInvalidSession
 	}
@@ -226,16 +231,13 @@ func (sc *SessionConfig) requestSession(r *http.Request) (*Session[map[string]an
 	// lookup userID in cache to ensure tokens match
 	userID, err := sc.RedisStore.GetSession(r.Context(), sessionID)
 	if err != nil {
-		log.Error().Err(err).Msg("unable to get session from store")
+		logx.FromContext(r.Context()).Error().Err(err).Msg("unable to get session from store")
 
 		return nil, "", ErrInvalidSession
 	}
 
 	if userIDFromCookie != userID {
-		log.Error().
-			Interface("cookie", userIDFromCookie).
-			Str("store", userID).
-			Msg("sessions do not match")
+		logx.FromContext(r.Context()).Error().Interface("cookie", userIDFromCookie).Str("store", userID).Msg("sessions do not match")
 
 		return nil, "", ErrInvalidSession
 	}
@@ -249,7 +251,7 @@ func (sc *SessionConfig) writeRefreshedSession(ctx context.Context, w http.Respo
 	// do not write session/cookie if context is cancelled
 	select {
 	case <-ctx.Done():
-		log.Debug().Msg("request context cancelled, skipping session save")
+		logx.FromContext(ctx).Debug().Msg("request context cancelled, skipping session save")
 
 		return ctx, false
 	default:
@@ -259,7 +261,7 @@ func (sc *SessionConfig) writeRefreshedSession(ctx context.Context, w http.Respo
 	// refresh and save session cookie
 	refreshed, err := sc.CreateAndStoreSession(ctx, w, userID)
 	if err != nil {
-		log.Error().Err(err).Msg("unable to create and store new session")
+		logx.FromContext(ctx).Error().Err(err).Msg("unable to create and store new session")
 
 		panic(err)
 	}


### PR DESCRIPTION
Logging in fgax and sessions used zerolog's global logger, so authz and session failures lost all request correlation (request ID, client metadata). This converts those call sites to logx.FromContext(ctx) from the new standalone logx package (context-scoped logger with global fallback) and fixes two noisy severities (missing session cookie: error -> debug; undecodable cookie on logout: error -> warn)